### PR TITLE
Rescue load error so rake tasks run on heroku

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,9 @@ require File.expand_path('../config/application', __FILE__)
 
 EntryApplication::Application.load_tasks
 
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:spec)
-task :default => :spec
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  task :default => :spec
+rescue LoadError
+end


### PR DESCRIPTION
We don't load test/development environment specific gems for heroku so we need
the Rakefile to respect that it may not be able to load rspec all the time.
