### PR TITLE
Upgrade to Ruby 3.0.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.7.8'
+ruby '3.0.7'
 gem 'rails', '~> 6.1.7', '>= 6.1.7.10'
 
 gem 'pg', '~> 1.4', '>= 1.4.6'
@@ -27,8 +27,8 @@ gem "blueimp-gallery"
 gem 'devise', '~> 4.4', '>= 4.4.3'
 gem 'cancancan', '~> 3.0'
 
-gem 'prawn', :git => 'https://github.com/prawnpdf/prawn.git'
-gem 'prawn-table'
+gem 'prawn', '~> 2.5'
+gem 'prawn-table', '~> 0.2', '>= 0.2.2'
 gem 'axlsx_rails'
 
 gem 'net-ssh'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/prawnpdf/prawn.git
-  revision: dc088578d12c1e44fb866176259dedda49c6c591
-  specs:
-    prawn (2.2.2)
-      pdf-core (~> 0.7.0)
-      ttfunk (~> 1.5)
-
-GIT
   remote: https://github.com/rweng/jquery-datatables-rails.git
   revision: d486b31b192a2924b1913e080ad23460e6b96d31
   specs:
@@ -87,6 +79,7 @@ GEM
       caxlsx (>= 3.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    bigdecimal (3.1.9)
     bindex (0.8.1)
     blueimp-gallery (2.11.0.1)
       railties (>= 3.1.0)
@@ -181,6 +174,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.4)
@@ -202,8 +196,12 @@ GEM
     nokogiri (1.15.7-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    pdf-core (0.7.0)
+    pdf-core (0.10.0)
     pg (1.5.9)
+    prawn (2.5.0)
+      matrix (~> 0.4)
+      pdf-core (~> 0.10.0)
+      ttfunk (~> 1.8)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
     protected_attributes_continued (1.9.0)
@@ -290,7 +288,8 @@ GEM
     thor (1.3.2)
     tilt (2.5.0)
     timeout (0.4.3)
-    ttfunk (1.5.1)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
@@ -342,8 +341,8 @@ DEPENDENCIES
   nested_form
   net-ssh
   pg (~> 1.4, >= 1.4.6)
-  prawn!
-  prawn-table
+  prawn (~> 2.5)
+  prawn-table (~> 0.2, >= 0.2.2)
   protected_attributes_continued
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
@@ -357,7 +356,7 @@ DEPENDENCIES
   webdrivers
 
 RUBY VERSION
-   ruby 2.7.8p225
+   ruby 3.0.7p220
 
 BUNDLED WITH
-   2.4.22
+   2.5.23


### PR DESCRIPTION
Prawn was seemingly the only gem that needed to be upgraded. I reviewed its changelog and nothing jumped out. I also manually tested logging into the application and downloading proofing reports (to exercise PDF generation).