### PR TITLE
Remove coffeescript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "puma", ">= 5.0"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 gem 'sass-rails', '~> 5.0'
-gem 'coffee-rails'
 gem 'jbuilder'
 
 gem 'jquery-ui-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,13 +140,6 @@ GEM
     caxlsx_rails (0.6.4)
       actionpack (>= 3.1)
       caxlsx (>= 3.0)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -162,7 +155,6 @@ GEM
       warden (~> 1.2.3)
     drb (2.2.1)
     erubi (1.13.1)
-    execjs (2.10.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.8.0)
@@ -370,7 +362,6 @@ DEPENDENCIES
   capistrano-rbenv (~> 2.1)
   capybara
   caxlsx_rails (= 0.6.4)
-  coffee-rails
   debug
   devise (~> 4.4, >= 4.4.3)
   factory_girl_rails


### PR DESCRIPTION
CoffeeScript is not used (and in general, is mostly dead/deprecated), and is no longer needed as a gem dependency.