### PR TITLE
Add passenger to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'capistrano-rbenv', '~> 2.1'
 
 group :production do
   gem 'rails_12factor'
+  gem 'passenger', '6.0.2'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,9 @@ GEM
     nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
     orm_adapter (0.5.0)
+    passenger (6.0.2)
+      rack
+      rake (>= 0.8.1)
     pdf-core (0.7.0)
     pg (0.20.0)
     prawn-table (0.2.2)
@@ -306,6 +309,7 @@ DEPENDENCIES
   multi_json
   nested_form
   net-ssh
+  passenger (= 6.0.2)
   pg
   prawn!
   prawn-table


### PR DESCRIPTION
`passenger` should be in the Gemfile so it is installed as part of the automated deploy process.

On the `next` branch, `passenger` goes away entirely so this is only temporary.