### PR TITLE
Use relative paths in case URLs do not generate properly because of proxying

### DIFF
--- a/app/views/benthic_covers/_form.html.erb
+++ b/app/views/benthic_covers/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form-horizontal">
-<%= nested_form_for @benthic_cover, data: { "drafts-url": draft_benthic_covers_url(id: @benthic_cover.id), "draft-restored": @draft.present?, "draft-focused-dom-id": @draft&.focused_dom_id } do |f| %>
+<%= nested_form_for @benthic_cover, data: { "drafts-url": draft_benthic_covers_path(id: @benthic_cover.id), "draft-restored": @draft.present?, "draft-focused-dom-id": @draft&.focused_dom_id } do |f| %>
   <%= render "shared/error_messages", :target => @benthic_cover %>
 
 

--- a/app/views/benthic_covers/edit.html.erb
+++ b/app/views/benthic_covers/edit.html.erb
@@ -1,5 +1,5 @@
 <h1>Editing Benthic Cover Sample <%=  @benthic_cover.field_id %></h1>
 
-<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_benthic_covers_url(id: @benthic_cover.id) } %>
+<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_benthic_covers_path(id: @benthic_cover.id) } %>
 
 <%= render 'form' %>

--- a/app/views/benthic_covers/new.html.erb
+++ b/app/views/benthic_covers/new.html.erb
@@ -1,6 +1,6 @@
 <h1>New benthic_cover</h1>
 
-<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_benthic_covers_url } %>
+<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_benthic_covers_path } %>
 
 <%= render 'form' %>
 

--- a/app/views/boat_logs/_form.html.erb
+++ b/app/views/boat_logs/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form-horizontal">
-<%= nested_form_for @boat_log, data: { "drafts-url": draft_boat_logs_url(id: @boat_log.id), "draft-restored": @draft.present?, "draft-focused-dom-id": @draft&.focused_dom_id } do |f| %>
+<%= nested_form_for @boat_log, data: { "drafts-url": draft_boat_logs_path(id: @boat_log.id), "draft-restored": @draft.present?, "draft-focused-dom-id": @draft&.focused_dom_id } do |f| %>
   <%= render "shared/error_messages", :target => @boat_log%>
 
     <div class="formContainer">

--- a/app/views/boat_logs/edit.html.erb
+++ b/app/views/boat_logs/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>Editing boat_log</h1>
 
-<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_boat_logs_url(id: @boat_log.id) } %>
+<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_boat_logs_path(id: @boat_log.id) } %>
 
 <%= render 'form' %>
 

--- a/app/views/boat_logs/new.html.erb
+++ b/app/views/boat_logs/new.html.erb
@@ -1,6 +1,6 @@
 <h1>New boat_log</h1>
 
-<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_boat_logs_url } %>
+<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_boat_logs_path } %>
 
 <%= render 'form' %>
 

--- a/app/views/coral_demographics/_form.html.erb
+++ b/app/views/coral_demographics/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form-horizontal">
-<%= nested_form_for @coral_demographic, data: { "drafts-url": draft_coral_demographics_url(id: @coral_demographic.id), "draft-restored": @draft.present?, "draft-focused-dom-id": @draft&.focused_dom_id } do |f| %>
+<%= nested_form_for @coral_demographic, data: { "drafts-url": draft_coral_demographics_path(id: @coral_demographic.id), "draft-restored": @draft.present?, "draft-focused-dom-id": @draft&.focused_dom_id } do |f| %>
   <%= render "shared/error_messages", :target => @coral_demographic%>
 
 

--- a/app/views/coral_demographics/edit.html.erb
+++ b/app/views/coral_demographics/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>Editing Coral Demographic Sample <%=  @coral_demographic.field_id %></h1>
 
-<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_coral_demographics_url(id: @coral_demographic.id) } %>
+<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_coral_demographics_path(id: @coral_demographic.id) } %>
 
 <%= render 'form' %>
 

--- a/app/views/coral_demographics/new.html.erb
+++ b/app/views/coral_demographics/new.html.erb
@@ -1,5 +1,5 @@
 <h1>New coral_demographic</h1>
 
-<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_coral_demographics_url } %>
+<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_coral_demographics_path } %>
 
 <%= render 'form' %>

--- a/app/views/samples/_form.html.erb
+++ b/app/views/samples/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form-horizontal">
-  <%= nested_form_for @sample, data: {"drafts-url": draft_samples_url(id: @sample.id), "draft-restored": @draft.present?, "draft-focused-dom-id": @draft&.focused_dom_id }, :validate => false do |f| %>
+  <%= nested_form_for @sample, data: {"drafts-url": draft_samples_path(id: @sample.id), "draft-restored": @draft.present?, "draft-focused-dom-id": @draft&.focused_dom_id }, :validate => false do |f| %>
 
   <%= render "shared/error_messages", :target => @sample%>
 

--- a/app/views/samples/edit.html.erb
+++ b/app/views/samples/edit.html.erb
@@ -1,5 +1,5 @@
 <h1>Editing sample <%= @sample.field_id %></h1>
 
-<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_samples_url(id: @sample.id) } %>
+<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_samples_path(id: @sample.id) } %>
 
 <%= render 'form' %>

--- a/app/views/samples/new.html.erb
+++ b/app/views/samples/new.html.erb
@@ -1,5 +1,5 @@
 <h1>New Fish Sample</h1>
 
-<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_samples_url } %>
+<%= render partial: "draft_present_alert", locals: { discard_draft_url: draft_samples_path } %>
 
 <%= render 'form' %>


### PR DESCRIPTION
The proxy is currently having the effect of confusing Rails' URL generation. This is mostly fixed in the `next` branch but I think it is simpler to use relative paths in this case anyway so I decided to fix it that way. I'll backport this to `next` to keep things in line.