### PR TITLE
PDFs must never be cached

### DIFF
--- a/app/controllers/benthic_covers_controller.rb
+++ b/app/controllers/benthic_covers_controller.rb
@@ -27,11 +27,11 @@ class BenthicCoversController < ApplicationController
       format.json { render json: @benthic_covers }
       format.xlsx
       format.pdf do 
-
         pdf = BenthicCoverPdf.new(proof_by_diver(params[:diver_id]||= current_diver))
+
+        expires_now
         send_data pdf.render, filename: "#{current_diver.lastname}_BenthicCoverReport.pdf",
                               type: "application/pdf"
-      
       end
     end
   end

--- a/app/controllers/coral_demographics_controller.rb
+++ b/app/controllers/coral_demographics_controller.rb
@@ -28,11 +28,11 @@ class CoralDemographicsController < ApplicationController
       format.json { render json: @coral_demographics }
       format.xlsx
       format.pdf do 
-
         pdf = CoralDemographicPdf.new(proof_by_diver(params[:diver_id]||= current_diver))
+
+        expires_now
         send_data pdf.render, filename: "#{current_diver.lastname}_CoralDemographicsReport.pdf",
                               type: "application/pdf"
-      
       end
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -29,11 +29,12 @@ class SamplesController < ApplicationController
       format.json { render json: @samples }
       format.xlsx
       format.pdf do
-
         pdf = SamplePdf.new(proof_by_diver(params[:diver_id]||= current_diver), params[:fishtype].to_s)
+                              Rails.logger.info response.method(:cache_control).source_location
+
+        expires_now 
         send_data pdf.render, filename: "#{current_diver.lastname}_ProofingReport.pdf",
                               type: "application/pdf"
-      
       end
     end
   end
@@ -48,6 +49,8 @@ class SamplesController < ApplicationController
       format.json { render json: @sample }
       format.pdf do
         pdf = SamplePdf.new(@sample)
+
+        expires_now
         send_data pdf.render, filename: "sample_#{@sample.field_id}.pdf",
                               type: "application/pdf",
                               disposition: "inline"
@@ -164,6 +167,8 @@ class SamplesController < ApplicationController
       format.json { render json: @sample }
       format.pdf do
         pdf = SamplePdf.new(@sample)
+
+        expires_now
         send_data pdf.render, filename: "sample_#{@sample.field_id}.pdf",
                               type: "application/pdf",
                               disposition: "inline"


### PR DESCRIPTION
This was more of a spelunk than I expected.

In Rails 5, there is a [workaround for old versions of Internet Explorer](https://github.com/rails/rails/blob/v5.1.1/actionpack/lib/action_controller/metal/data_streaming.rb#L147) that sets the `Cache-Control` header to `private`. This (inadvertently?) overrides the default `Cache-Control` header that would later be set as `max-age=0, private, must-revalidate` by the `Rack::ETag` middleware.

Without the other directives like `max-age` set explicitly to 0, something else in the chain of proxies takes the liberty of adding `max-age=86400`, allowing the PDF reports to be cached privately (by the browser) for up to a day.

I do not think this "spooky action at a distance" was intended, and is really just an accident of code coming together in an unfortunate way.

This resolves itself in future versions of Rails where the IE workaround code goes away, but it also cannot hurt to explicitly say that the PDF reports expire immediately and should not be cached. That is what the `expires_now` method does.