### PR TITLE
Make data table links explicit in most cases

### DIFF
--- a/app/views/benthic_covers/index.html.erb
+++ b/app/views/benthic_covers/index.html.erb
@@ -9,15 +9,20 @@
            <th>field ID</th>
            <th>Date</th>
            <th>Sample Start Time</th>
+           <th></th>
          </tr>
        </thead>
        <tbody>
       <% @benthic_covers.each do |benthic_cover| %>
-        <tr data-link=" <%= benthic_cover_path(benthic_cover.id) %> ">
+        <tr>
           <td><%= benthic_cover.diver.diver_name %></td>
           <td class='fieldid_check'><%= benthic_cover.field_id %></td>
           <td><%= benthic_cover.sample_date %></td>
           <td><%= benthic_cover.sample_begin_time.strftime("%H:%M") %></td>
+          <td>
+            <%= link_to "View", benthic_cover %>
+            <%= link_to "Edit", edit_benthic_cover_path(benthic_cover) %>
+          </td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/boat_logs/index.html.erb
+++ b/app/views/boat_logs/index.html.erb
@@ -9,15 +9,20 @@
            <th>Date</th>
            <th>Time</th>
            <th>Comments</th>
+           <th></th>
          </tr>
        </thead>
        <tbody>
       <% @boat_logs.each do |log| %>
-        <tr data-link=" <%= boat_log_path(log.id) %> ">
+        <tr>
           <td><%= log.primary_sample_unit %></td>
           <td class='fieldid_check'><%= log.date %></td>
           <td><%= log.station_logs.first.time.strftime("%H:%M") %></td>
           <td><%= log.station_logs.first.comments %></td>
+          <td>
+            <%= link_to "View", log %>
+            <%= link_to "Edit", edit_boat_log_path(log) %>
+          </td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/boatlog_managers/index.html.erb
+++ b/app/views/boatlog_managers/index.html.erb
@@ -11,11 +11,14 @@
   </thead>
   <tbody>
 <% @boatlog_managers.each do |boatlog_manager| %>
-  <tr data-link=" <%= edit_boatlog_manager_path(boatlog_manager.id) %> ">
+  <tr>
     <td><%= boatlog_manager.agency %></td>
     <td><%= boatlog_manager.firstname %></td>
     <td><%= boatlog_manager.lastname %></td>
-    <td><%= link_to 'Destroy', boatlog_manager, data: { confirm: 'Are you sure?' }, method: :delete %></td>
+    <td>
+      <%= link_to 'Edit', edit_boatlog_manager_path(boatlog_manager) %>
+      <%= link_to 'Destroy', boatlog_manager, data: { confirm: 'Are you sure?' }, method: :delete %>
+    </td>
   </tr>
 <% end %>
 </tbody>

--- a/app/views/coral_demographics/index.html.erb
+++ b/app/views/coral_demographics/index.html.erb
@@ -9,15 +9,20 @@
            <th>field ID</th>
            <th>Date</th>
            <th>Sample Start Time</th>
+           <th></th>
          </tr>
        </thead>
        <tbody>
       <% @coral_demographics.each do |coral_demographic| %>
-        <tr data-link=" <%= coral_demographic_path(coral_demographic.id) %> ">
+        <tr>
           <td><%= coral_demographic.diver.diver_name %></td>
           <td class='fieldid_check'><%= coral_demographic.field_id %></td>
           <td><%= coral_demographic.sample_date %></td>
           <td><%= coral_demographic.sample_begin_time.strftime("%H:%M") %></td>
+          <td>
+            <%= link_to "View", coral_demographic %>
+            <%= link_to "Edit", edit_coral_demographic_path(coral_demographic) %>
+          </td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/samples/index.html.erb
+++ b/app/views/samples/index.html.erb
@@ -9,15 +9,20 @@
            <th>field ID</th>
            <th>Date</th>
            <th>Sample Start Time</th>
+           <th></th>
          </tr>
        </thead>
        <tbody>
       <% @samples.each do |sample| %>
-        <tr data-link=" <%= sample_path(sample) %> " data-id="<%= sample.id %>">
+        <tr data-id="<%= sample.id %>">
           <td><%= sample.diver_samples.primary.first.diver.diver_name %></td>
           <td class='fieldid_check'><%= sample.field_id %></td>
           <td><%= sample.sample_date %></td>
           <td><%= sample.sample_begin_time.strftime("%H:%M") %></td>
+          <td>
+            <%= link_to "View", sample %>
+            <%= link_to "Edit", edit_sample_path(sample) %>
+          </td>
         </tr>
       <% end %>
       </tbody>


### PR DESCRIPTION
Right now the click event on the row means any link inside the row cannot actually be clicked. While clicking anywhere on the row is convenient,
it is probably not the best thing to train people to look for and it has this
strange behavior currently.