### PR TITLE
Do not remove hidden fields when validating

### DIFF
--- a/app/assets/javascripts/samples.js.erb
+++ b/app/assets/javascripts/samples.js.erb
@@ -380,8 +380,6 @@ $(function(){
   $("#validateAnimals").click(function(){
     $('.validateIcon').empty();
 
-    $('#animals div.fields:hidden').remove();
-    
     $('#animals').find('input:enabled').each(function(){
       $('.new_sample, .edit_sample').validate().element(this);
     });


### PR DESCRIPTION
This will remove hidden _destroy fields which are needed to notify Rails to delete an existing nested record.