### PR TITLE
Make water temperature an integer (whole numbers only)

### DIFF
--- a/db/migrate/20250516182921_change_water_temp_to_integer.rb
+++ b/db/migrate/20250516182921_change_water_temp_to_integer.rb
@@ -1,0 +1,9 @@
+class ChangeWaterTempToInteger < ActiveRecord::Migration[5.1]
+  def up
+    change_column :samples, :water_temp, :integer
+  end
+
+  def down
+    change_column :samples, :water_temp, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20250205190547) do
+ActiveRecord::Schema.define(version: 20250516182921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -241,7 +241,7 @@ ActiveRecord::Schema.define(version: 20250205190547) do
     t.integer "rubble_percentage"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.float "water_temp"
+    t.integer "water_temp"
     t.string "current", limit: 255
     t.integer "boatlog_manager_id"
     t.integer "substrate_max_depth"


### PR DESCRIPTION
Water temperature does not need decimal precision. And as it stands, it being a float in the database is not correctly aligned with the client-side validation that it be digits (whole numbers) only.

This is effectively a non-destructive operation in this case. In the real data, all of the water temperatures are rounded off because the client-side validation enforces it. Therefore, the database can convert floats to ints without data loss. I tested this locally with a data dump and the water temperatures were correctly converted to integers in the database.