### PR TITLE
Make proofing report generation more consistent

### DIFF
--- a/app/controllers/benthic_covers_controller.rb
+++ b/app/controllers/benthic_covers_controller.rb
@@ -6,13 +6,6 @@ class BenthicCoversController < ApplicationController
   # GET /benthic_covers
   # GET /benthic_covers.json
   def index
-    def proof_by_diver(d)
-      if d.is_a?(String)
-        Diver.find(d).diver_proofing_benthic_cover
-      else
-        Diver.find(d.id).diver_proofing_benthic_cover
-      end
-    end
     if current_diver.role == 'admin'
       @benthic_covers = BenthicCover.all
     elsif current_diver.role == 'manager'
@@ -21,17 +14,17 @@ class BenthicCoversController < ApplicationController
       @benthic_covers = current_diver.benthic_covers
     end
 
-    @proofing_bentic_covers = current_diver.diver_proofing_benthic_cover
     respond_to do |format|
       format.html # index.html.erb
       format.json { render json: @benthic_covers }
       format.xlsx
       format.pdf do 
-        pdf = BenthicCoverPdf.new(proof_by_diver(params[:diver_id]||= current_diver))
+        diver = Diver.find(params[:diver_id].presence || current_diver.id)
+        pdf = BenthicCoverPdf.new(diver.diver_proofing_benthic_cover)
 
         expires_now
-        send_data pdf.render, filename: "#{current_diver.lastname}_BenthicCoverReport.pdf",
-                              type: "application/pdf"
+        send_data pdf.render, filename: "#{diver.diver_name}_BenthicCoverReport.pdf",
+          type: "application/pdf"
       end
     end
   end

--- a/app/controllers/coral_demographics_controller.rb
+++ b/app/controllers/coral_demographics_controller.rb
@@ -6,13 +6,6 @@ class CoralDemographicsController < ApplicationController
   # GET /coral_demographics
   # GET /coral_demographics.json
   def index
-    def proof_by_diver(d)
-      if d.is_a?(String) == true
-        Diver.find(d).diver_proofing_coral_demo
-      else 
-        Diver.find(d.id).diver_proofing_coral_demo
-      end
-    end
     if current_diver.role == 'admin'
       @coral_demographics = CoralDemographic.all
     elsif current_diver.role == 'manager'
@@ -21,18 +14,17 @@ class CoralDemographicsController < ApplicationController
       @coral_demographics = current_diver.coral_demographics
     end
 
-    @proofing_coral_demographics = current_diver.diver_proofing_coral_demo
-
     respond_to do |format|
       format.html # index.html.erb
       format.json { render json: @coral_demographics }
       format.xlsx
       format.pdf do 
-        pdf = CoralDemographicPdf.new(proof_by_diver(params[:diver_id]||= current_diver))
+        diver = Diver.find(params[:diver_id].presence || current_diver.id)
+        pdf = CoralDemographicPdf.new(diver.diver_proofing_coral_demo)
 
         expires_now
-        send_data pdf.render, filename: "#{current_diver.lastname}_CoralDemographicsReport.pdf",
-                              type: "application/pdf"
+        send_data pdf.render, filename: "#{diver.diver_name}_CoralDemographicsReport.pdf",
+          type: "application/pdf"
       end
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -10,9 +10,6 @@ class SamplesController < ApplicationController
   # GET /samples
   # GET /samples.json
   def index
-    def proof_by_diver(d)
-      Diver.find(d).diver_proofing_samples
-    end
     if current_diver.role == 'admin'
       @samples = Sample.all
     elsif current_diver.role == 'manager'
@@ -21,20 +18,17 @@ class SamplesController < ApplicationController
       @samples = current_diver.samples.merge(DiverSample.primary)
     end
     
-     #@proofing_samples = current_diver.samples.merge(DiverSample.primary).order("sample_date") 
-      @proofing_samples = current_diver.diver_proofing_samples
-    
     respond_to do |format|
       format.html # index.html.erb
       format.json { render json: @samples }
       format.xlsx
       format.pdf do
-        pdf = SamplePdf.new(proof_by_diver(params[:diver_id]||= current_diver), params[:fishtype].to_s)
-                              Rails.logger.info response.method(:cache_control).source_location
+        diver = Diver.find(params[:diver_id].presence || current_diver.id)
+        pdf = SamplePdf.new(diver.diver_proofing_samples, params[:fishtype].to_s)
 
         expires_now 
-        send_data pdf.render, filename: "#{current_diver.lastname}_ProofingReport.pdf",
-                              type: "application/pdf"
+        send_data pdf.render, filename: "#{diver.diver_name}_ProofingReport.pdf",
+          type: "application/pdf"
       end
     end
   end

--- a/app/pdfs/coral_demographic_pdf.rb
+++ b/app/pdfs/coral_demographic_pdf.rb
@@ -51,7 +51,7 @@ class CoralDemographicPdf < Prawn::Document
  def spp_1_30
   [[ "M", "Species", "MD      PD      MH", "OM%", "RM%", "Blch", "Dis"]] + 
   @coral_demographic.demographic_corals[0..29].map.with_index do |spp, index|
-    [spp.meter_mark, spp.coral.code , "%s  -  %s  -  %s" % [spp.try(:max_diameter), spp.try(:perpendicular_diameter), spp.try(:height)], spp.old_mortality, spp.recent_mortality, spp.bleach_condition, spp.disease]
+    [spp.meter_mark, spp.coral.try(:code) , "%s  -  %s  -  %s" % [spp.try(:max_diameter), spp.try(:perpendicular_diameter), spp.try(:height)], spp.old_mortality, spp.recent_mortality, spp.bleach_condition, spp.disease]
   end
  end
 
@@ -67,7 +67,7 @@ class CoralDemographicPdf < Prawn::Document
  def spp_31_60
   [[ "M", "Species", "MD      PD      MH", "OM%", "RM%", "Blch", "Dis"]] + 
     @coral_demographic.demographic_corals[30..59].map.with_index do |spp, index|
-    [spp.meter_mark, spp.coral.code , "%s  -  %s  -  %s" % [spp.try(:max_diameter), spp.try(:perpendicular_diameter), spp.try(:height)], spp.old_mortality, spp.recent_mortality, spp.bleach_condition, spp.disease]
+    [spp.meter_mark, spp.coral.try(:code) , "%s  -  %s  -  %s" % [spp.try(:max_diameter), spp.try(:perpendicular_diameter), spp.try(:height)], spp.old_mortality, spp.recent_mortality, spp.bleach_condition, spp.disease]
   end
  end
  
@@ -80,7 +80,7 @@ class CoralDemographicPdf < Prawn::Document
  def spp_61_90
   [[ "M", "Species", "MD      PD      MH", "OM%", "RM%", "Blch", "Dis"]] + 
   @coral_demographic.demographic_corals[60..89].map.with_index do |spp, index|
-    [spp.meter_mark, spp.coral.code , "%s  -  %s  -  %s" % [spp.try(:max_diameter), spp.try(:perpendicular_diameter), spp.try(:height)], spp.old_mortality, spp.recent_mortality, spp.bleach_condition, spp.disease]
+    [spp.meter_mark, spp.coral.try(:code) , "%s  -  %s  -  %s" % [spp.try(:max_diameter), spp.try(:perpendicular_diameter), spp.try(:height)], spp.old_mortality, spp.recent_mortality, spp.bleach_condition, spp.disease]
   end
  end
 
@@ -96,7 +96,7 @@ class CoralDemographicPdf < Prawn::Document
  def spp_91_120
   [[ "M", "Species", "MD      PD      MH", "OM%", "RM%", "Blch", "Dis"]] + 
   @coral_demographic.demographic_corals[90..119].map.with_index do |spp, index|
-    [spp.meter_mark, spp.coral.code , "%s  -  %s  -  %s" % [spp.try(:max_diameter), spp.try(:perpendicular_diameter), spp.try(:height)], spp.old_mortality, spp.recent_mortality, spp.bleach_condition, spp.disease]
+    [spp.meter_mark, spp.coral.try(:code) , "%s  -  %s  -  %s" % [spp.try(:max_diameter), spp.try(:perpendicular_diameter), spp.try(:height)], spp.old_mortality, spp.recent_mortality, spp.bleach_condition, spp.disease]
   end
  end
 end

--- a/app/views/benthic_covers/index.html.erb
+++ b/app/views/benthic_covers/index.html.erb
@@ -32,11 +32,11 @@
     <%= button_to('New LPI', new_benthic_cover_path, :method => "get", :class => 'btn btn-large btn-primary wrap')  %>   
   </div>
   <div id="downloadSampleButton"> 
-    <%= button_to('Download Proofing Report (.pdf)', benthic_covers_path(format: "pdf", diver_id: current_diver.id), :method => "get", :class => 'btn btn-small btn-primary')  %>   
+    <%= link_to('Download Proofing Report (.pdf)', benthic_covers_path(format: "pdf", diver_id: current_diver.id), :class => 'btn btn-small btn-primary')  %>   
   </div>
 <% if !current_diver.diver? %>
   <div id="downloadXLSXButton"> 
-    <%= button_to('Download Samples (.xlsx)', benthic_covers_path(format: "xlsx"), :method => "get", :class => 'btn btn-small btn-primary')  %>   
+    <%= link_to('Download Samples (.xlsx)', benthic_covers_path(format: "xlsx"), :class => 'btn btn-small btn-primary')  %>   
   </div>
 <% end %>
 
@@ -47,7 +47,7 @@
     </button>
       <ul class="dropdown-menu" role="menu">
         <% current_diver.boatlog_manager.divers_responsible_for.each do |diver| %>
-          <li> <%= link_to(diver.diver_name, benthic_covers_path(format: "pdf", diver_id: diver.id), :method => "get") %> </li>
+          <li> <%= link_to(diver.diver_name, benthic_covers_path(format: "pdf", diver_id: diver.id)) %> </li>
         <% end %>
       </ul>
   </div>

--- a/app/views/coral_demographics/index.html.erb
+++ b/app/views/coral_demographics/index.html.erb
@@ -32,11 +32,11 @@
     <%= button_to('New Demo', new_coral_demographic_path, :method => "get", :class => 'btn btn-large btn-primary wrap')  %>   
   </div>
   <div id="downloadSampleButton"> 
-    <%= button_to('Download Proofing Report (.pdf)', coral_demographics_path(format: "pdf", diver_id: current_diver.id), :method => "get", :class => 'btn btn-small btn-primary')  %>   
+    <%= link_to('Download Proofing Report (.pdf)', coral_demographics_path(format: "pdf", diver_id: current_diver.id), :class => 'btn btn-small btn-primary')  %>   
   </div>
 <% if !current_diver.diver? %>
   <div id="downloadXLSXButton"> 
-    <%= button_to('Download Samples (.xlsx)', coral_demographics_path(format: "xlsx"), :method => "get", :class => 'btn btn-small btn-primary')  %>   
+    <%= link_to('Download Samples (.xlsx)', coral_demographics_path(format: "xlsx"), :class => 'btn btn-small btn-primary')  %>   
   </div>
 <% end %>
 
@@ -47,7 +47,7 @@
     </button>
       <ul class="dropdown-menu" role="menu">
         <% current_diver.boatlog_manager.divers_responsible_for.each do |diver| %>
-          <li> <%= link_to(diver.diver_name, coral_demographics_path(format: "pdf", diver_id: diver.id), :method => "get") %> </li>
+          <li> <%= link_to(diver.diver_name, coral_demographics_path(format: "pdf", diver_id: diver.id)) %> </li>
         <% end %>
       </ul>
   </div>

--- a/app/views/samples/index.html.erb
+++ b/app/views/samples/index.html.erb
@@ -33,16 +33,16 @@
   </div>
   
   <div id="downloadSampleButton"> 
-    <%= link_to('Download Proofing Report (Species Code)', samples_path(format: "pdf", diver_id: current_diver.id, fishtype: "species_code"), :method => "get", :class => 'btn btn-small btn-primary')  %>   
+    <%= link_to('Download Proofing Report (Species Code)', samples_path(format: "pdf", diver_id: current_diver.id, fishtype: "species_code"), :class => 'btn btn-small btn-primary')  %>   
   </div>
 
   <div id="downloadSampleButton2"> 
-    <%= link_to('Download Proofing Report (Common Name)', samples_path(format: "pdf", diver_id: current_diver.id, fishtype: "common_name"), :method => "get", :class => 'btn btn-small btn-primary')  %>   
+    <%= link_to('Download Proofing Report (Common Name)', samples_path(format: "pdf", diver_id: current_diver.id, fishtype: "common_name"), :class => 'btn btn-small btn-primary')  %>   
   </div>
 
 <% if !current_diver.diver? %>
   <div id="downloadXLSXButton"> 
-    <%= button_to('Download Samples (.xlsx)', samples_path(format: "xlsx"), :method => "get", :class => 'btn btn-small btn-primary')  %>   
+    <%= link_to('Download Samples (.xlsx)', samples_path(format: "xlsx"), :class => 'btn btn-small btn-primary')  %>   
   </div>
 <% end %>
 <% if current_diver.manager? %>
@@ -52,7 +52,7 @@
     </button>
       <ul class="dropdown-menu" role="menu">
         <% current_diver.boatlog_manager.divers_responsible_for.each do |diver| %>
-          <li> <%= link_to(diver.diver_name, samples_path(format: "pdf", diver_id: diver.id, fishtype: "common_name"), :method => "get") %> </li>
+          <li> <%= link_to(diver.diver_name, samples_path(format: "pdf", diver_id: diver.id, fishtype: "common_name")) %> </li>
         <% end %>
       </ul>
   </div>


### PR DESCRIPTION
Something about `button_to` and possibly rails-ujs(?) are interacting in a confusing way that is causing divers to get proofing reports that are not their own, or the ones they requested.

This PR makes the code to generate the report a bit clearer, and also replaces forms with simpler `link_to` that should have fewer confusing interactions with JavaScript.

Fixes #97 