### PR TITLE
Remove JSON and MultiJSON gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,6 @@ gem 'puma', '>= 5.0', '< 6'
 # will no longer work after Rails 6.1
 gem 'protected_attributes_continued'
 
-# TODO: Evaluate whether these gems are needed anymore.
-gem 'json'
-gem 'multi_json'
-
 gem 'sass-rails', '~> 5.0'
 
 gem 'jquery-ui-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,6 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     jquery-validation-rails (1.16.0)
-    json (2.1.0)
     logger (1.7.0)
     loofah (2.24.1)
       crass (~> 1.0.2)
@@ -153,7 +152,6 @@ GEM
     mini_portile2 (2.6.1)
     minitest (5.15.0)
     msgpack (1.8.0)
-    multi_json (1.12.1)
     nested_form (0.3.2)
     net-imap (0.2.2)
       digest
@@ -297,8 +295,6 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails (~> 5.0)
   jquery-validation-rails
-  json
-  multi_json
   nested_form
   pg
   prawn!


### PR DESCRIPTION
JSON is built into Ruby these days, and MultiJSON is not explicitly used anywhere.