### PR TITLE
Replace protected_attributes with strong_parameters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,6 @@ gem 'pg'
 # < 6 until Ruby 2.7. Bump capybara alongside that too.
 gem 'puma', '>= 5.0', '< 6'
 
-# TODO: Replace with strong_parameters. This gem is no longer maintained and
-# will no longer work after Rails 6.1
-gem 'protected_attributes_continued'
-
 gem 'sass-rails', '~> 5.0'
 
 gem 'jquery-ui-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,8 +181,6 @@ GEM
     pg (0.20.0)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    protected_attributes_continued (1.9.0)
-      activemodel (>= 5.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -299,7 +297,6 @@ DEPENDENCIES
   pg
   prawn!
   prawn-table
-  protected_attributes_continued
   pry
   puma (>= 5.0, < 6)
   rails (~> 5.2.8, >= 5.2.8.1)

--- a/app/controllers/animals_controller.rb
+++ b/app/controllers/animals_controller.rb
@@ -1,14 +1,11 @@
 class AnimalsController < ApplicationController
-  # GET /animals
-  # GET /animals.json
-  #
-
   before_action :authenticate_diver!
   load_and_authorize_resource
 
+  # GET /animals
+  # GET /animals.json
   def index
     @animals = Animal.all
-
 
     respond_to do |format|
       format.html # index.html.erb
@@ -53,7 +50,7 @@ class AnimalsController < ApplicationController
   # POST /animals
   # POST /animals.json
   def create
-    @animal = Animal.new(params[:animal])
+    @animal = Animal.new(animal_params)
 
     respond_to do |format|
       if @animal.save
@@ -72,7 +69,7 @@ class AnimalsController < ApplicationController
     @animal = Animal.find(params[:id])
 
     respond_to do |format|
-      if @animal.update_attributes(params[:animal])
+      if @animal.update(animal_params)
         format.html { redirect_to animal_url(@animal), notice: 'Animal was successfully updated.' }
         format.json { head :no_content }
       else
@@ -94,4 +91,13 @@ class AnimalsController < ApplicationController
     end
   end
 
+  private
+
+  def animal_params
+    # TODO: Allowing all keys is intentional to reduce risk of a Rails upgrade.
+    # Prior to Rails 7, the application used `attr_protected []` at the model
+    # level. Mass attribute protection will be introduced gradually separate
+    # from the Rails upgrade itself.
+    params.require(:animal).permit!
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,23 +1,22 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
-  
+
   def current_ability
     @current_ability ||= Ability.new(current_diver)
   end
 
-  
   rescue_from CanCan::AccessDenied do |exception|
     flash[:alert] = "Access denied!"
     redirect_to root_url
   end
-    protected
 
-    def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit({ roles: [] }, :email, :password, :password_confirmation, :username) }
-      #devise_parameter_sanitizer.permit(:sign_up) << :firstname << :lastname << :email
-      #devise_parameter_sanitizer.permit(:account_update) << :firstname << :lastname << :email
-      devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:firstname, :lastname, :email, :username, :password, :password_confirmation, :current_password)  }
-    end
+  protected
 
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit({ roles: [] }, :email, :password, :password_confirmation, :username) }
+    #devise_parameter_sanitizer.permit(:sign_up) << :firstname << :lastname << :email
+    #devise_parameter_sanitizer.permit(:account_update) << :firstname << :lastname << :email
+    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:firstname, :lastname, :email, :username, :password, :password_confirmation, :current_password)  }
+  end
 end

--- a/app/controllers/benthic_covers_controller.rb
+++ b/app/controllers/benthic_covers_controller.rb
@@ -1,5 +1,4 @@
 class BenthicCoversController < ApplicationController
-
   before_action :authenticate_diver!
   load_and_authorize_resource
 
@@ -99,7 +98,7 @@ class BenthicCoversController < ApplicationController
     @benthic_cover = BenthicCover.find(params[:id])
 
     respond_to do |format|
-      if @benthic_cover.update_attributes(benthic_cover_params)
+      if @benthic_cover.update(benthic_cover_params)
         Draft.destroy_for(diver_id: current_diver.id, model_klass: BenthicCover, model_id: @benthic_cover.id)
 
         format.html { redirect_to benthic_covers_path, notice: 'Benthic cover was successfully updated.' }

--- a/app/controllers/boat_logs_controller.rb
+++ b/app/controllers/boat_logs_controller.rb
@@ -1,8 +1,7 @@
 class BoatLogsController < ApplicationController
-  
   before_action :authenticate_diver!
   load_and_authorize_resource
-  
+
   # GET /boat_logs
   # GET /boat_logs.json
   def index
@@ -63,7 +62,7 @@ class BoatLogsController < ApplicationController
   # POST /boat_logs
   # POST /boat_logs.json
   def create
-    @boat_log = BoatLog.new(params[:boat_log])
+    @boat_log = BoatLog.new(boat_log_params)
 
     respond_to do |format|
       if @boat_log.save
@@ -84,7 +83,7 @@ class BoatLogsController < ApplicationController
     @boat_log = BoatLog.find(params[:id])
 
     respond_to do |format|
-      if @boat_log.update_attributes(params[:boat_log])
+      if @boat_log.update(boat_log_params)
         Draft.destroy_for(diver_id: current_diver.id, model_klass: BoatLog, model_id: @boat_log.id)
 
         format.html { redirect_to @boat_log, notice: 'Boat log was successfully updated.' }
@@ -122,7 +121,7 @@ class BoatLogsController < ApplicationController
       diver_id: current_diver.id,
       model_klass: BoatLog,
       model_id: params[:id],
-      model_attributes: params[:boat_log],
+      model_attributes: boat_log_params,
       sequence: params[:sequence],
       focused_dom_id: params[:focused_dom_id],
     )
@@ -131,5 +130,15 @@ class BoatLogsController < ApplicationController
     else
       render json: draft.errors, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def boat_log_params
+    # TODO: Allowing all keys is intentional to reduce risk of a Rails upgrade.
+    # Prior to Rails 7, the application used `attr_protected []` at the model
+    # level. Mass attribute protection will be introduced gradually separate
+    # from the Rails upgrade itself.
+    params.require(:boat_log).permit!
   end
 end

--- a/app/controllers/boatlog_managers_controller.rb
+++ b/app/controllers/boatlog_managers_controller.rb
@@ -1,5 +1,4 @@
 class BoatlogManagersController < ApplicationController
-  
   before_action :authenticate_diver!
   load_and_authorize_resource
 
@@ -44,7 +43,7 @@ class BoatlogManagersController < ApplicationController
   # POST /boatlog_managers
   # POST /boatlog_managers.json
   def create
-    @boatlog_manager = BoatlogManager.new(params[:boatlog_manager])
+    @boatlog_manager = BoatlogManager.new(boatlog_manager_params)
 
     respond_to do |format|
       if @boatlog_manager.save
@@ -63,7 +62,7 @@ class BoatlogManagersController < ApplicationController
     @boatlog_manager = BoatlogManager.find(params[:id])
 
     respond_to do |format|
-      if @boatlog_manager.update_attributes(params[:boatlog_manager])
+      if @boatlog_manager.update(boatlog_manager_params)
         format.html { redirect_to @boatlog_manager, notice: 'Boatlog manager was successfully updated.' }
         format.json { head :no_content }
       else
@@ -83,5 +82,15 @@ class BoatlogManagersController < ApplicationController
       format.html { redirect_to boatlog_managers_url }
       format.json { head :no_content }
     end
+  end
+
+  private
+
+  def boatlog_manager_params
+    # TODO: Allowing all keys is intentional to reduce risk of a Rails upgrade.
+    # Prior to Rails 7, the application used `attr_protected []` at the model
+    # level. Mass attribute protection will be introduced gradually separate
+    # from the Rails upgrade itself.
+    params.require(:boatlog_manager).permit!
   end
 end

--- a/app/controllers/coral_demographics_controller.rb
+++ b/app/controllers/coral_demographics_controller.rb
@@ -1,5 +1,4 @@
 class CoralDemographicsController < ApplicationController
-
   before_action :authenticate_diver!
   load_and_authorize_resource
 
@@ -75,7 +74,7 @@ class CoralDemographicsController < ApplicationController
   # POST /coral_demographics
   # POST /coral_demographics.json
   def create
-    @coral_demographic = CoralDemographic.new(params[:coral_demographic])
+    @coral_demographic = CoralDemographic.new(coral_demographic_params)
 
     respond_to do |format|
       if @coral_demographic.save
@@ -96,7 +95,7 @@ class CoralDemographicsController < ApplicationController
     @coral_demographic = CoralDemographic.find(params[:id])
 
     respond_to do |format|
-      if @coral_demographic.update_attributes(params[:coral_demographic])
+      if @coral_demographic.update(coral_demographic_params)
         Draft.destroy_for(diver_id: current_diver.id, model_klass: CoralDemographic, model_id: @coral_demographic.id)
 
         format.html { redirect_to coral_demographics_path, notice: 'Coral demographic was successfully updated.' }
@@ -134,7 +133,7 @@ class CoralDemographicsController < ApplicationController
       diver_id: current_diver.id,
       model_klass: CoralDemographic,
       model_id: params[:id],
-      model_attributes: params[:coral_demographic],
+      model_attributes: coral_demographic_params,
       sequence: params[:sequence],
       focused_dom_id: params[:focused_dom_id],
     )
@@ -143,5 +142,15 @@ class CoralDemographicsController < ApplicationController
     else
       render json: draft.errors, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def coral_demographic_params
+    # TODO: Allowing all keys is intentional to reduce risk of a Rails upgrade.
+    # Prior to Rails 7, the application used `attr_protected []` at the model
+    # level. Mass attribute protection will be introduced gradually separate
+    # from the Rails upgrade itself.
+    params.require(:coral_demographic).permit!
   end
 end

--- a/app/controllers/corals_controller.rb
+++ b/app/controllers/corals_controller.rb
@@ -1,5 +1,4 @@
 class CoralsController < ApplicationController
-
   before_action :authenticate_diver!
   load_and_authorize_resource
 
@@ -44,7 +43,7 @@ class CoralsController < ApplicationController
   # POST /corals
   # POST /corals.json
   def create
-    @coral = Coral.new(params[:coral])
+    @coral = Coral.new(coral_params)
 
     respond_to do |format|
       if @coral.save
@@ -63,7 +62,7 @@ class CoralsController < ApplicationController
     @coral = Coral.find(params[:id])
 
     respond_to do |format|
-      if @coral.update_attributes(params[:coral])
+      if @coral.update(coral_params)
         format.html { redirect_to @coral, notice: 'Coral was successfully updated.' }
         format.json { head :no_content }
       else
@@ -83,5 +82,15 @@ class CoralsController < ApplicationController
       format.html { redirect_to corals_url }
       format.json { head :no_content }
     end
+  end
+
+  private
+
+  def coral_params
+    # TODO: Allowing all keys is intentional to reduce risk of a Rails upgrade.
+    # Prior to Rails 7, the application used `attr_protected []` at the model
+    # level. Mass attribute protection will be introduced gradually separate
+    # from the Rails upgrade itself.
+    params.require(:coral).permit!
   end
 end

--- a/app/controllers/cover_cats_controller.rb
+++ b/app/controllers/cover_cats_controller.rb
@@ -1,5 +1,4 @@
 class CoverCatsController < ApplicationController
-
   before_action :authenticate_diver!
   load_and_authorize_resource
 
@@ -44,7 +43,7 @@ class CoverCatsController < ApplicationController
   # POST /cover_cats
   # POST /cover_cats.json
   def create
-    @cover_cat = CoverCat.new(params[:cover_cat])
+    @cover_cat = CoverCat.new(cover_cat_params)
 
     respond_to do |format|
       if @cover_cat.save
@@ -63,7 +62,7 @@ class CoverCatsController < ApplicationController
     @cover_cat = CoverCat.find(params[:id])
 
     respond_to do |format|
-      if @cover_cat.update_attributes(params[:cover_cat])
+      if @cover_cat.update(cover_cat_params)
         format.html { redirect_to @cover_cat, notice: 'Cover cat was successfully updated.' }
         format.json { head :no_content }
       else
@@ -83,5 +82,15 @@ class CoverCatsController < ApplicationController
       format.html { redirect_to cover_cats_url }
       format.json { head :no_content }
     end
+  end
+
+  private
+
+  def cover_cat_params
+    # TODO: Allowing all keys is intentional to reduce risk of a Rails upgrade.
+    # Prior to Rails 7, the application used `attr_protected []` at the model
+    # level. Mass attribute protection will be introduced gradually separate
+    # from the Rails upgrade itself.
+    params.require(:cover_cat).permit!
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,10 +1,8 @@
 class DashboardController < ApplicationController
- 
   before_action :authenticate_diver!
   before_action :manager_or_admin?
  
  def show
-  #binding.pry
   if current_diver.admin?
     @boat_logs = BoatLog.all
     @dashSamples = Sample.all
@@ -50,11 +48,9 @@ class DashboardController < ApplicationController
       coral_demographic_path(coral_demographic)
     end
   end
-
  end
- 
- helper_method :send_to_path
 
+ helper_method :send_to_path
 
  protected
 
@@ -67,6 +63,4 @@ class DashboardController < ApplicationController
       false
     end
   end
-
-
 end

--- a/app/controllers/divers_controller.rb
+++ b/app/controllers/divers_controller.rb
@@ -1,9 +1,7 @@
 class DiversController < ApplicationController
- 
-  
   before_action :authenticate_diver!
   load_and_authorize_resource
-  
+
   # GET /divers
   # GET /divers.json
   def index
@@ -49,9 +47,7 @@ class DiversController < ApplicationController
   # POST /divers
   # POST /divers.json
   def create
-    role = params[:diver].delete(:role)
-    @diver = Diver.new(params[:diver])
-    @diver.role = role if current_diver.admin?
+    @diver = Diver.new(diver_params)
 
     respond_to do |format|
       if @diver.save
@@ -68,11 +64,9 @@ class DiversController < ApplicationController
   # PUT /divers/1.json
   def update
     @diver = Diver.find(params[:id])
-    role = params[:diver].delete(:role)
-    @diver.role = role if current_diver.admin?
 
     respond_to do |format|
-      if @diver.update_attributes(params[:diver])
+      if @diver.update(diver_params)
         format.html { redirect_to @diver, notice: 'Diver was successfully updated.' }
         format.json { head :no_content }
       else
@@ -92,5 +86,18 @@ class DiversController < ApplicationController
       format.html { redirect_to divers_url }
       format.json { head :no_content }
     end
+  end
+
+  private
+
+  def diver_params
+    allowed_keys = [
+      :active, :diver_number, :diver_name, :username, :password, :password_confirmation, :firstname,
+      :lastname, :email, :current_password, :boatlog_manager_id
+    ]
+
+    allowed_keys << :role if current_diver.admin?
+
+    params.require(:diver).permit(*allowed_keys)
   end
 end

--- a/app/controllers/habitat_types_controller.rb
+++ b/app/controllers/habitat_types_controller.rb
@@ -1,5 +1,4 @@
 class HabitatTypesController < ApplicationController
- 
   before_action :authenticate_diver!
   load_and_authorize_resource
   
@@ -44,7 +43,7 @@ class HabitatTypesController < ApplicationController
   # POST /habitat_types
   # POST /habitat_types.json
   def create
-    @habitat_type = HabitatType.new(params[:habitat_type])
+    @habitat_type = HabitatType.new(habitat_type_params)
 
     respond_to do |format|
       if @habitat_type.save
@@ -63,7 +62,7 @@ class HabitatTypesController < ApplicationController
     @habitat_type = HabitatType.find(params[:id])
 
     respond_to do |format|
-      if @habitat_type.update_attributes(params[:habitat_type])
+      if @habitat_type.update(habitat_type_params)
         format.html { redirect_to @habitat_type, notice: 'Habitat type was successfully updated.' }
         format.json { head :no_content }
       else
@@ -83,5 +82,15 @@ class HabitatTypesController < ApplicationController
       format.html { redirect_to habitat_types_url }
       format.json { head :no_content }
     end
+  end
+
+  private
+
+  def habitat_type_params
+    # TODO: Allowing all keys is intentional to reduce risk of a Rails upgrade.
+    # Prior to Rails 7, the application used `attr_protected []` at the model
+    # level. Mass attribute protection will be introduced gradually separate
+    # from the Rails upgrade itself.
+    params.require(:habitat_type).permit!
   end
 end

--- a/app/controllers/sample_types_controller.rb
+++ b/app/controllers/sample_types_controller.rb
@@ -1,8 +1,7 @@
 class SampleTypesController < ApplicationController
-  
   before_action :authenticate_diver!
   load_and_authorize_resource
-  
+
   # GET /sample_types
   # GET /sample_types.json
   def index
@@ -44,7 +43,7 @@ class SampleTypesController < ApplicationController
   # POST /sample_types
   # POST /sample_types.json
   def create
-    @sample_type = SampleType.new(params[:sample_type])
+    @sample_type = SampleType.new(sample_type_params)
 
     respond_to do |format|
       if @sample_type.save
@@ -63,7 +62,7 @@ class SampleTypesController < ApplicationController
     @sample_type = SampleType.find(params[:id])
 
     respond_to do |format|
-      if @sample_type.update_attributes(params[:sample_type])
+      if @sample_type.update(sample_type_params)
         format.html { redirect_to @sample_type, notice: 'Sample type was successfully updated.' }
         format.json { head :no_content }
       else
@@ -83,5 +82,15 @@ class SampleTypesController < ApplicationController
       format.html { redirect_to sample_types_url }
       format.json { head :no_content }
     end
+  end
+
+  private
+
+  def sample_type_params
+    # TODO: Allowing all keys is intentional to reduce risk of a Rails upgrade.
+    # Prior to Rails 7, the application used `attr_protected []` at the model
+    # level. Mass attribute protection will be introduced gradually separate
+    # from the Rails upgrade itself.
+    params.require(:sample_type).permit!
   end
 end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1,5 +1,4 @@
 class SamplesController < ApplicationController
-
   before_action :authenticate_diver!
   load_and_authorize_resource
 
@@ -88,7 +87,7 @@ class SamplesController < ApplicationController
   # POST /samples
   # POST /samples.json
   def create
-    @sample = Sample.new(params[:sample])
+    @sample = Sample.new(sample_params)
 
     respond_to do |format|
       if @sample.save
@@ -109,7 +108,7 @@ class SamplesController < ApplicationController
     @sample = Sample.find(params[:id])
 
     respond_to do |format|
-      if @sample.update_attributes(params[:sample])
+      if @sample.update(sample_params)
         Draft.destroy_for(diver_id: current_diver.id, model_klass: Sample, model_id: @sample.id)
 
         format.html { redirect_to samples_path, notice: 'Sample was successfully updated.' }
@@ -147,7 +146,7 @@ class SamplesController < ApplicationController
       diver_id: current_diver.id,
       model_klass: Sample,
       model_id: params[:id],
-      model_attributes: params[:sample],
+      model_attributes: sample_params,
       sequence: params[:sequence],
       focused_dom_id: params[:focused_dom_id],
     )
@@ -159,7 +158,6 @@ class SamplesController < ApplicationController
   end
 
   def proofing_template
-
     @sample = Sample.find(params[:id])
 
     respond_to do |format|
@@ -175,5 +173,15 @@ class SamplesController < ApplicationController
                               disposition: "inline"
       end
     end
+  end
+
+  private
+
+  def sample_params
+    # TODO: Allowing all keys is intentional to reduce risk of a Rails upgrade.
+    # Prior to Rails 7, the application used `attr_protected []` at the model
+    # level. Mass attribute protection will be introduced gradually separate
+    # from the Rails upgrade itself.
+    params.require(:sample).permit!
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,7 +4,7 @@ class StaticPagesController < ApplicationController
 
   def help
   end
-  
+
   def diver_gallery
   end
 end

--- a/app/models/animal.rb
+++ b/app/models/animal.rb
@@ -1,7 +1,4 @@
 class Animal < ActiveRecord::Base
-  
-  attr_protected []
-
   has_many :sample_animals, :dependent => :destroy
   has_many :samples, :through => :sample_animals
   accepts_nested_attributes_for :sample_animals, :allow_destroy => true
@@ -26,5 +23,4 @@ class Animal < ActiveRecord::Base
       species_code
     end
   end
-
 end

--- a/app/models/benthic_cover.rb
+++ b/app/models/benthic_cover.rb
@@ -1,8 +1,6 @@
 class BenthicCover < ActiveRecord::Base
   include CommonFields
 
-  #attr_protected []
-
   has_many :point_intercepts, :dependent => :destroy
   has_many :cover_cats, :through => :point_intercepts
   accepts_nested_attributes_for :point_intercepts, :allow_destroy => true
@@ -34,5 +32,4 @@ class BenthicCover < ActiveRecord::Base
   def msn_prefix
     "X"
   end
-
 end

--- a/app/models/boat_log.rb
+++ b/app/models/boat_log.rb
@@ -1,6 +1,4 @@
 class BoatLog < ActiveRecord::Base  
-  attr_protected []
-  
   belongs_to :boatlog_manager
 
   has_many :station_logs, :dependent => :destroy
@@ -21,6 +19,4 @@ class BoatLog < ActiveRecord::Base
     end
     boatlog_divers_list.sort_by { |e| e[0] }
   end
-
-
 end

--- a/app/models/boatlog_manager.rb
+++ b/app/models/boatlog_manager.rb
@@ -1,5 +1,4 @@
 class BoatlogManager < ActiveRecord::Base
-  attr_protected []
   has_many  :samples
   has_one   :diver
   has_many  :benthic_covers
@@ -88,7 +87,4 @@ class BoatlogManager < ActiveRecord::Base
   def missing_samples_from_boatlog
     samples_diver_entered - boatlog_diver_list
   end
-
-
 end
-

--- a/app/models/coral.rb
+++ b/app/models/coral.rb
@@ -1,6 +1,4 @@
 class Coral < ActiveRecord::Base
-
-  attr_protected []
   has_many :demographic_corals
   has_many :coral_demographics, :through => :demographic_corals
   accepts_nested_attributes_for :demographic_corals, :allow_destroy => true
@@ -11,6 +9,4 @@ class Coral < ActiveRecord::Base
   def coral_code_name
     [self.code, self.scientific_name].join(" __ ")
   end
-  
-
 end

--- a/app/models/coral_demographic.rb
+++ b/app/models/coral_demographic.rb
@@ -1,7 +1,4 @@
 class CoralDemographic < ActiveRecord::Base
-
-  attr_protected []
-
   include CommonFields
 
   has_many :demographic_corals, :dependent => :destroy
@@ -28,5 +25,4 @@ class CoralDemographic < ActiveRecord::Base
   def msn_prefix
     "Y"
   end
-
 end

--- a/app/models/cover_cat.rb
+++ b/app/models/cover_cat.rb
@@ -1,7 +1,4 @@
 class CoverCat < ActiveRecord::Base
-  attr_protected []
-  
-  
   has_many :point_intercepts
   has_many :benthic_covers, :through => :point_intercepts
   accepts_nested_attributes_for :point_intercepts
@@ -11,5 +8,4 @@ class CoverCat < ActiveRecord::Base
   def cover_code_name
     [self.code, self.common].join(" __ ")
   end
-
 end

--- a/app/models/demographic_coral.rb
+++ b/app/models/demographic_coral.rb
@@ -1,6 +1,4 @@
 class DemographicCoral < ActiveRecord::Base
-  attr_protected []
-
   belongs_to :coral_demographic
   belongs_to :coral
 
@@ -8,5 +6,4 @@ class DemographicCoral < ActiveRecord::Base
   validates   :meter_mark, :max_diameter, :perpendicular_diameter, :height, :old_mortality, :recent_mortality, :bleach_condition, :disease, :presence => true, if: -> {coral_id != 1}
   validates   :max_diameter, :perpendicular_diameter, :height, :numericality => { :greater_than => 0 }
   validates   :perpendicular_diameter, :numericality => { :less_than_or_equal_to => :max_diameter }
-
 end

--- a/app/models/diver.rb
+++ b/app/models/diver.rb
@@ -8,9 +8,6 @@ class Diver < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  # Setup accessible (or protected) attributes for your model
-  attr_protected []
-  #attr_accessible :email, :password, :password_confirmation, :remember_me, :username, :firstname, :lastname, :diver_name, :diver_number, :active, :boatlog_manager_id
   belongs_to  :boatlog_manager
   has_many    :diver_samples
   has_many    :samples, :through => :diver_samples, :dependent => :destroy

--- a/app/models/diver_sample.rb
+++ b/app/models/diver_sample.rb
@@ -1,6 +1,4 @@
 class DiverSample < ActiveRecord::Base
-  attr_protected []
-
   belongs_to :diver
   belongs_to :sample
 

--- a/app/models/habitat_type.rb
+++ b/app/models/habitat_type.rb
@@ -1,5 +1,4 @@
 class HabitatType < ActiveRecord::Base
-  attr_protected []
   has_many :samples
   has_many :benthic_covers
 
@@ -10,5 +9,4 @@ class HabitatType < ActiveRecord::Base
   validates :habitat_name, :presence => true
   validates :habitat_description, :presence => true
   validates :region, :presence => true
-
 end

--- a/app/models/invert_belt.rb
+++ b/app/models/invert_belt.rb
@@ -1,9 +1,5 @@
 class InvertBelt < ActiveRecord::Base
-  attr_protected []
-
   belongs_to :benthic_cover
-
-
 
   validates :lobster_num,     :presence => true
   validates :conch_num,       :presence => true

--- a/app/models/point_intercept.rb
+++ b/app/models/point_intercept.rb
@@ -1,7 +1,4 @@
 class PointIntercept < ActiveRecord::Base
-  
-  attr_protected []
-
   belongs_to  :benthic_cover
   belongs_to  :cover_cat
 
@@ -11,5 +8,4 @@ class PointIntercept < ActiveRecord::Base
   def cover_total
     [hardbottom_num, softbottom_num, rubble_num].reject{|a| a.nil?}.sum
   end
-
 end

--- a/app/models/rep_log.rb
+++ b/app/models/rep_log.rb
@@ -1,15 +1,9 @@
 class RepLog < ActiveRecord::Base
-  
-  attr_protected []
-
   belongs_to  :station_log
   belongs_to  :diver
 
   validates :replicate,               :presence => true
   validates_format_of :replicate,     :with => /[a-zA-Z]/, :message => "Not one of Valid Letters"
-  
-
-  #default_scope :order => "id ASC"
 
   def field_id
     return [self.station_log.boat_log.primary_sample_unit,self.station_log.stn_number, self.replicate.upcase ].join("")
@@ -18,5 +12,4 @@ class RepLog < ActiveRecord::Base
   def replicate=(value)
     write_attribute(:replicate, value.upcase)
   end
-
 end

--- a/app/models/rugosity_measure.rb
+++ b/app/models/rugosity_measure.rb
@@ -1,7 +1,5 @@
 class RugosityMeasure < ActiveRecord::Base
-  attr_protected []
-
-belongs_to :benthic_cover
+  belongs_to :benthic_cover
 
   validates :min_depth,               :presence => true
   validates :max_depth,               :presence => true
@@ -22,10 +20,8 @@ belongs_to :benthic_cover
   validates :meter_mark_14,           :presence => true,  if: -> { rug_meters_completed >= 14 }
   validates :meter_mark_15,           :presence => true,  if: -> { rug_meters_completed >= 15 }
 
-
   def category_sum
     [meter_mark_1, meter_mark_2, meter_mark_3, meter_mark_4, meter_mark_5, meter_mark_6, meter_mark_7, meter_mark_8, meter_mark_9, meter_mark_10,
     meter_mark_11, meter_mark_12, meter_mark_13, meter_mark_14, meter_mark_15].sum
   end
-
 end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -1,7 +1,5 @@
 class Sample < ActiveRecord::Base
   include CommonFields
-  
-  attr_protected []
 
   belongs_to :sample_type
   belongs_to :habitat_type
@@ -158,5 +156,4 @@ class Sample < ActiveRecord::Base
         errors.add( :base, "Hardbottom biotic percentages do not add to 100" )
       end
   end
-
 end

--- a/app/models/sample_animal.rb
+++ b/app/models/sample_animal.rb
@@ -1,13 +1,10 @@
 class SampleAnimal < ActiveRecord::Base
-  attr_protected []
-
   belongs_to :animal
   belongs_to :sample
 
   def get_common
     Animal.find(self.animal_id).common_name
   end
-
 
   default_scope -> { order("id ASC") }
   validates             :animal_id,           :presence => true
@@ -42,6 +39,4 @@ class SampleAnimal < ActiveRecord::Base
       false
     end
   end
-
-
 end

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -1,5 +1,4 @@
 class SampleType < ActiveRecord::Base
-  attr_protected []
   has_many :samples
 
   validates :sample_type_name, :presence => true

--- a/app/models/station_log.rb
+++ b/app/models/station_log.rb
@@ -1,7 +1,4 @@
 class StationLog < ActiveRecord::Base
-  
-  attr_protected []
-
   belongs_to :boat_log
   has_many :rep_logs, :dependent => :destroy
   accepts_nested_attributes_for :rep_logs, :allow_destroy => true


### PR DESCRIPTION
This applies #30 to the `master` branch.

Rails 4 introduced `strong_parameters` as a different way to enforce mass assignment on Rails models. Instead of permitting attributes at the model layer, they are filtered at the controller layer.

Eventually we should loop back and restrict these attributes, but it is not super important at the moment because it just perpetuates the current behavior forward for the time being.