### PR TITLE
Add required packages for Chrome within Vagrant

### DIFF
--- a/server/playbook.yml
+++ b/server/playbook.yml
@@ -576,6 +576,8 @@
       ansible.builtin.package:
         name:
           - xdg-utils # for chrome/chromedriver
+          - libgbm1 # for chrome/chromedriver
+          - libasound2 # chrome chrome/chromedriver
       become: true
       when: development_build is defined
 


### PR DESCRIPTION
These packages are required for `chrome` to run in headless mode on Linux, which is required to run browser-based system tests within the Vagrant VM.

These packages will only be installed within Vagrant, not in production.