### PR TITLE
Update to new gem name, caxslx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'cancancan', '~> 2.0'
 
 gem 'prawn', :git => 'https://github.com/prawnpdf/prawn.git'
 gem 'prawn-table'
-gem 'axlsx_rails'
+gem 'caxlsx_rails'
 
 gem "blueimp-gallery"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,9 +65,6 @@ GEM
     airbrussh (1.5.3)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (9.0.0)
-    axlsx_rails (0.6.1)
-      actionpack (>= 3.1)
-      caxlsx (>= 3.0)
     base64 (0.3.0)
     bcrypt (3.1.20)
     blueimp-gallery (2.11.0.1)
@@ -104,6 +101,9 @@ GEM
       marcel (~> 1.0)
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (>= 1.3.0, < 3)
+    caxlsx_rails (0.6.4)
+      actionpack (>= 3.1)
+      caxlsx (>= 3.0)
     childprocess (3.0.0)
     coderay (1.1.1)
     concurrent-ruby (1.3.5)
@@ -279,7 +279,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  axlsx_rails
   blueimp-gallery
   bootsnap (>= 1.1.0)
   bootstrap-datepicker-rails
@@ -288,6 +287,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rbenv
   capybara (>= 2.15)
+  caxlsx_rails
   devise (~> 4.4, >= 4.4.3)
   factory_bot_rails (~> 5.2, < 6)
   faker (~> 2.22)


### PR DESCRIPTION
Nothing substantially changed as far as I can tell from the [CHANGELOG](https://github.com/caxlsx/caxlsx_rails/blob/master/CHANGELOG.md), but we are getting a deprecation warning about this new name, so this should clear it up.