### PR TITLE
Remove git dependencies in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,22 +10,22 @@ gem 'puma', '>= 5.0', '< 6'
 
 gem 'sass-rails', '~> 5.0'
 
-gem 'jquery-ui-rails', '~> 5.0'
-gem 'jquery-rails'
-gem 'jquery-datatables-rails', git: 'https://github.com/rweng/jquery-datatables-rails.git'
-gem 'jquery-validation-rails'
+gem 'jquery-ui-rails', '5.0.5'
+gem 'jquery-rails', '4.3.1'
+gem 'jquery-datatables-rails', '3.4.0'
+gem 'jquery-validation-rails', '1.16.0'
 
 gem 'twitter-bootstrap-rails', '2.2.8'
-gem 'bootstrap-datepicker-rails'
+gem 'bootstrap-datepicker-rails', '1.6.4.1'
 
 gem 'select2-rails', '3.2.1'
-gem 'nested_form'
+gem 'nested_form', '0.3.2'
 
 gem 'devise', '~> 4.4', '>= 4.4.3'
 gem 'cancancan', '~> 2.0'
 
-gem 'prawn', :git => 'https://github.com/prawnpdf/prawn.git'
-gem 'prawn-table'
+gem 'prawn', '~> 2.2', '>= 2.2.2'
+gem 'prawn-table', '~> 0.2', '>= 0.2.2'
 gem 'caxlsx_rails'
 
 gem "blueimp-gallery"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,3 @@
-GIT
-  remote: https://github.com/prawnpdf/prawn.git
-  revision: dc088578d12c1e44fb866176259dedda49c6c591
-  specs:
-    prawn (2.2.2)
-      pdf-core (~> 0.7.0)
-      ttfunk (~> 1.5)
-
-GIT
-  remote: https://github.com/rweng/jquery-datatables-rails.git
-  revision: d486b31b192a2924b1913e080ad23460e6b96d31
-  specs:
-    jquery-datatables-rails (3.4.0)
-      actionpack (>= 3.1)
-      jquery-rails
-      railties (>= 3.1)
-      sass-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -130,6 +112,11 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-wait (0.3.1)
+    jquery-datatables-rails (3.4.0)
+      actionpack (>= 3.1)
+      jquery-rails
+      railties (>= 3.1)
+      sass-rails
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -179,6 +166,9 @@ GEM
     ostruct (0.6.2)
     pdf-core (0.7.0)
     pg (0.20.0)
+    prawn (2.2.2)
+      pdf-core (~> 0.7.0)
+      ttfunk (~> 1.5)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
     pry (0.10.4)
@@ -256,7 +246,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.7)
     timeout (0.4.0)
-    ttfunk (1.5.1)
+    ttfunk (1.7.0)
     twitter-bootstrap-rails (2.2.8)
       actionpack (>= 3.1)
       execjs
@@ -279,7 +269,7 @@ PLATFORMS
 DEPENDENCIES
   blueimp-gallery
   bootsnap (>= 1.1.0)
-  bootstrap-datepicker-rails
+  bootstrap-datepicker-rails (= 1.6.4.1)
   cancancan (~> 2.0)
   capistrano
   capistrano-rails
@@ -289,14 +279,14 @@ DEPENDENCIES
   devise (~> 4.4, >= 4.4.3)
   factory_bot_rails (~> 5.2, < 6)
   faker (~> 2.22)
-  jquery-datatables-rails!
-  jquery-rails
-  jquery-ui-rails (~> 5.0)
-  jquery-validation-rails
-  nested_form
+  jquery-datatables-rails (= 3.4.0)
+  jquery-rails (= 4.3.1)
+  jquery-ui-rails (= 5.0.5)
+  jquery-validation-rails (= 1.16.0)
+  nested_form (= 0.3.2)
   pg
-  prawn!
-  prawn-table
+  prawn (~> 2.2, >= 2.2.2)
+  prawn-table (~> 0.2, >= 0.2.2)
   pry
   puma (>= 5.0, < 6)
   rails (~> 5.2.8, >= 5.2.8.1)


### PR DESCRIPTION
Keeps the same version for the commit, but takes them from rubygems.org instead of git. This just makes things a little easier to work with and speeds up setup.