### PR TITLE
Replace sass-rails with dartsass-sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,8 @@ gem 'pg'
 # < 6 until Ruby 2.7. Bump capybara alongside that too.
 gem 'puma', '>= 5.0', '< 6'
 
-gem 'sass-rails', '~> 5.0'
+# TODO: Update after upgrade to Ruby >= 3.1
+gem 'dartsass-sprockets', '~> 3.0'
 
 gem 'jquery-ui-rails', '5.0.5'
 gem 'jquery-rails', '4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,14 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
+    dartsass-ruby (3.0.2)
+      sass-embedded (~> 1.54, < 1.67)
+    dartsass-sprockets (3.0.0)
+      dartsass-ruby (~> 3.0)
+      railties (>= 4.0.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -120,6 +128,7 @@ GEM
     ffi (1.17.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    google-protobuf (3.25.8)
     htmlentities (4.3.4)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
@@ -234,6 +243,9 @@ GEM
     rubyzip (2.4.1)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
+    sass-embedded (1.63.6)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -299,6 +311,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   caxlsx_rails
   concurrent-ruby (< 1.3.5)
+  dartsass-sprockets (~> 3.0)
   devise (~> 4.9, >= 4.9.4)
   factory_bot_rails (~> 5.2, < 6)
   faker (~> 2.22)
@@ -314,7 +327,6 @@ DEPENDENCIES
   pry
   puma (>= 5.0, < 6)
   rails (~> 6.0, >= 6.0.6.1)
-  sass-rails (~> 5.0)
   select2-rails (= 3.2.1)
   selenium-webdriver
   twitter-bootstrap-rails (= 2.2.8)


### PR DESCRIPTION
`sass-rails` is long deprecated, and does not support the latest features in Sass