### PR TITLE
Update net-* gems to address deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,13 +107,13 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    date (3.4.1)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    digest (3.2.0)
     erubi (1.13.1)
     execjs (2.10.0)
     factory_bot (5.2.0)
@@ -130,7 +130,6 @@ GEM
     htmlentities (4.3.4)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    io-wait (0.3.1)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -150,24 +149,20 @@ GEM
     minitest (5.15.0)
     msgpack (1.8.0)
     nested_form (0.3.2)
-    net-imap (0.2.2)
-      digest
+    net-imap (0.4.22)
+      date
       net-protocol
-      strscan
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.2)
-      io-wait
+    net-protocol (0.2.2)
       timeout
     net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
-    net-smtp (0.3.0)
-      digest
+    net-smtp (0.5.1)
       net-protocol
-      timeout
-    net-ssh (6.1.0)
+    net-ssh (7.3.0)
     nio4r (2.7.3)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
@@ -248,11 +243,10 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
-    strscan (3.1.5)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.7)
-    timeout (0.4.0)
+    timeout (0.4.3)
     ttfunk (1.7.0)
     twitter-bootstrap-rails (2.2.8)
       actionpack (>= 3.1)


### PR DESCRIPTION
These gems are used by `mail` under the hood.

Update them now that we have updated Ruby.