### PR TITLE
Allow single-digit substrate depths

### DIFF
--- a/app/assets/javascripts/samples.js
+++ b/app/assets/javascripts/samples.js
@@ -797,12 +797,12 @@ $(function () {
       "sample[substrate_max_depth]": {
         required: true,
         digits: true,
-        minlength: 2,
+        min: 1,
       },
       "sample[substrate_min_depth]": {
         required: true,
         digits: true,
-        minlength: 2,
+        min: 1,
         lessThanEqualTo: "#sample_substrate_max_depth",
       },
       "sample[hard_verticle_relief]": {


### PR DESCRIPTION
A diver from the July STX mission reported that there were some very shallow sites where these depths needed to be entered as, e.g., `4`. They worked around it by entering `04` in the mean time.