### PR TITLE
Cordon uswds style compilation to its own file

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,6 +2,7 @@
 //= link_tree ../images
 //= link application.css
 //= link application-uswds.css
+//= link uswds-styles.css
 //= link application.js
 
 // USWDS assets

--- a/app/assets/stylesheets/application-uswds.css.scss
+++ b/app/assets/stylesheets/application-uswds.css.scss
@@ -3,7 +3,3 @@
 //= require jquery.timeentry
 //= require datatables.net-dt/css/dataTables.dataTables
 //= require_self
-
-@forward "uswds-theme";
-@forward "uswds";
-@forward "uswds-theme-custom-styles";

--- a/app/assets/stylesheets/uswds-styles.css.scss
+++ b/app/assets/stylesheets/uswds-styles.css.scss
@@ -1,0 +1,3 @@
+@forward "uswds-theme";
+@forward "uswds";
+@forward "uswds-theme-custom-styles";

--- a/app/views/layouts/application-uswds.html.erb
+++ b/app/views/layouts/application-uswds.html.erb
@@ -8,7 +8,7 @@
 
     <%= yield :head %>
 
-    <%= stylesheet_link_tag "application-uswds", :media => "all" %>
+    <%= stylesheet_link_tag "uswds-styles", "application-uswds", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <%= javascript_include_tag "@uswds/uswds/dist/js/uswds-init" %>
   </head>


### PR DESCRIPTION
This makes stylesheet development much faster when developing locally, at the minimal added cost of one more asset to serve later.

USWDS takes a relatively long time to compile from scratch, so separating it to its own linked asset means it will only be compiled once at boot and anytime settings that _only_ affect it change. Modifying other styles in application-uswds.css or other required files no longer trigger that lengthy compilation.