### PR TITLE
Require files in alphabetical order

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -15,9 +15,9 @@
  *= require jquery.timeentry
  *= require datatables.net-dt/css/dataTables.dataTables
  *
- *= require ./bootstrap_and_overrides
  *= require ./animals
  *= require ./benthic_covers
+ *= require ./bootstrap_and_overrides
  *= require ./boat_logs
  *= require ./coral_demographics
  *= require ./corals


### PR DESCRIPTION
I inadvertently reordered these during a different refactoring, and unfortunately order seems to matter here. The LPI form got a bit misaligned with the prior ordering.

Ideally our CSS is not so order-dependent, but while it is, I will avoid changing it.