### PR TITLE
Remove need for .js.erb

### DIFF
--- a/app/assets/javascripts/samples.js
+++ b/app/assets/javascripts/samples.js
@@ -450,7 +450,7 @@ $(function () {
   enable_disable_animals_fields();
 
   $("#validateAnimals").click(function () {
-    $(".validateIcon").empty();
+    $(".validateCross, .validateCheck").hide();
 
     $("#animals")
       .find("input:enabled")
@@ -459,9 +459,9 @@ $(function () {
       });
 
     if ($("#animals").find("input:visible.error").length > 0) {
-      $(".validateIcon").prepend('<img src= <%= asset_path("cross.png") %> />');
+      $(".validateCross").show();
     } else {
-      $(".validateIcon").prepend('<img src= <%= asset_path("check.png") %> />');
+      $(".validateCheck").show();
       $("#submitButton").attr("disabled", false);
     }
   });
@@ -934,7 +934,7 @@ $(function () {
   validate_fields();
   $(document).delegate(".add_nested_fields", "click", function () {
     validate_fields();
-    $(".validateIcon").empty();
+    $(".validateCross, .validateCheck").hide();
     $("#submitButton").attr("disabled", true);
   });
 
@@ -942,7 +942,7 @@ $(function () {
     $("input.error").each(function () {
       $("form").validate().element(this);
     });
-    $(".validateIcon").empty();
+    $(".validateCross, .validateCheck").hide();
     $("#submitButton").attr("disabled", true);
   });
 

--- a/app/views/samples/_form.html.erb
+++ b/app/views/samples/_form.html.erb
@@ -246,7 +246,10 @@
  
 
   <div class="actions">
-    <button type="button" class="btn" id="validateAnimals">Validate Species</button><span class="validateIcon"></span>
+    <button type="button" class="btn" id="validateAnimals">Validate Species</button>
+    <span class="validateCross" style="display: none;"><%= image_tag "cross.png" %></span>
+    <span class="validateCheck" style="display: none;"><%= image_tag "check.png" %></span>
+
     <%= f.submit "Submit Sample", :id => "submitButton" %>
   </div>
 


### PR DESCRIPTION
While .js.erb files are allowed, they are more difficult to work with because they require preprocessing with ERB before they are valid JS files. They are also pretty unique to Sprockets in Rails.

We only have one .js.erb file and it's pretty trivial to replace it with a static JS file that simply shows or hides an icon.