### PR TITLE
Wrap Rubocop and Prettier with a single bin/lint script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,8 @@ jobs:
       - name: Install NodeJS dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Lint Ruby with Rubocop
-        run: bin/rubocop -f github
-
-      - name: Lint JS and CSS with Prettier
-        run: bin/yarn prettier --check app/assets/**/*.{js,css,scss}
+      - name: Lint
+        run: bin/lint
 
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -94,16 +94,10 @@ bin/rails test:system
 
 Most formatting errors can be automatically corrected by the tools themselves.
 
-To run Rubocop and autocorrect any Ruby issues, connect to the Vagrant VM (`vagrant ssh`) and run:
+To run Rubocop and Prettier _and_ autocorrect any issues if possible, connect to the Vagrant VM (`vagrant ssh`) and run:
 
 ```bash
-bin/rubocop --autocorrect
-```
-
-To run Prettier and autocorrect any JS or CSS issues, connect to the Vagrant VM (`vagrant ssh`) and run:
-
-```bash
-bin/yarn prettier --write app/assets/**/*.{js,css,scss}
+bin/lint --autocorrect
 ```
 
 ### Data

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+autocorrect=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --autocorrect|-a)
+    autocorrect="1"
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    exit 1
+    ;;
+  esac
+
+  shift
+done
+
+if [ -n "$autocorrect" ]; then
+  rubocop_args=(--autocorrect)
+  prettier_args=(--write)
+else
+  rubocop_args=()
+  prettier_args=(--check)
+fi
+
+set -x
+bin/rubocop "${rubocop_args[@]}"
+bin/yarn prettier "${prettier_args[@]}" "app/assets/**/*.{js,css,scss}"


### PR DESCRIPTION
Remembering `bin/lint` is easier than the individual commands.