### PR TITLE
Quiet benign deprecation warnings

### DIFF
--- a/config/initializers/sass.rb
+++ b/config/initializers/sass.rb
@@ -1,0 +1,5 @@
+# Silence some currently-benign deprecation warnings until USWDS addresses them.
+Rails.application.config.sass.silence_deprecations = [
+  "mixed-decls",
+  "global-builtin",
+]


### PR DESCRIPTION
USWDS raises a few deprecation warnings. They know about them and they'll presumably be addressed at some point, so there is no point in printing them every time. They are very verbose and noisy.