### PR TITLE
Draft: only assign valid attribute keys

### DIFF
--- a/app/controllers/benthic_covers_controller.rb
+++ b/app/controllers/benthic_covers_controller.rb
@@ -49,7 +49,7 @@ class BenthicCoversController < ApplicationController
   def new
     @draft = Draft.latest_for(diver_id: current_diver.id, model_klass: BenthicCover, model_id: nil)
     if @draft
-      @benthic_cover = BenthicCover.new(@draft.model_attributes)
+      @benthic_cover = @draft.assign_attributes_to(BenthicCover.new)
     else
       @benthic_cover = BenthicCover.new.tap do |b|
         b.sample_date ||= Date.current
@@ -71,7 +71,7 @@ class BenthicCoversController < ApplicationController
   def edit
     @draft = Draft.latest_for(diver_id: current_diver.id, model_klass: BenthicCover, model_id: params[:id])
     if @draft
-      @benthic_cover.assign_attributes(@draft.model_attributes)
+      @draft.assign_attributes_to(@benthic_cover)
     end
   end
 

--- a/app/controllers/boat_logs_controller.rb
+++ b/app/controllers/boat_logs_controller.rb
@@ -37,7 +37,7 @@ class BoatLogsController < ApplicationController
   def new
     @draft = Draft.latest_for(diver_id: current_diver.id, model_klass: BoatLog, model_id: nil)
     if @draft
-      @boat_log = BoatLog.new(@draft.model_attributes)
+      @boat_log = @draft.assign_attributes_to(BoatLog.new)
     else
       @boat_log = BoatLog.new.tap do |bl|
         bl.date ||= Date.current
@@ -56,7 +56,7 @@ class BoatLogsController < ApplicationController
   def edit
     @draft = Draft.latest_for(diver_id: current_diver.id, model_klass: BoatLog, model_id: params[:id])
     if @draft
-      @boat_log.assign_attributes(@draft.model_attributes)
+      @draft.assign_attributes_to(@boat_log)
     end
   end
 

--- a/app/controllers/coral_demographics_controller.rb
+++ b/app/controllers/coral_demographics_controller.rb
@@ -49,7 +49,7 @@ class CoralDemographicsController < ApplicationController
   def new
     @draft = Draft.latest_for(diver_id: current_diver.id, model_klass: CoralDemographic, model_id: nil)
     if @draft
-      @coral_demographic = CoralDemographic.new(@draft.model_attributes)
+      @coral_demographic = @draft.assign_attributes_to(CoralDemographic.new)
     else
       @coral_demographic = CoralDemographic.new.tap do |c|
         c.sample_date ||= Date.current
@@ -68,7 +68,7 @@ class CoralDemographicsController < ApplicationController
   def edit
     @draft = Draft.latest_for(diver_id: current_diver.id, model_klass: CoralDemographic, model_id: params[:id])
     if @draft
-      @coral_demographic.assign_attributes(@draft.model_attributes)
+      @draft.assign_attributes_to(@coral_demographic)
     end
   end
 

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -62,7 +62,7 @@ class SamplesController < ApplicationController
   def new
     @draft = Draft.latest_for(diver_id: current_diver.id, model_klass: Sample, model_id: nil)
     if @draft
-      @sample = Sample.new(@draft.model_attributes)
+      @sample = @draft.assign_attributes_to(Sample.new)
     else
       @sample = Sample.new.tap do |s|
         s.sample_date ||= Date.current
@@ -81,7 +81,7 @@ class SamplesController < ApplicationController
   def edit
     @draft = Draft.latest_for(diver_id: current_diver.id, model_klass: Sample, model_id: params[:id])
     if @draft
-      @sample.assign_attributes(@draft.model_attributes)
+      @draft.assign_attributes_to(@sample)
     end
   end
 

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -35,4 +35,13 @@ class Draft < ActiveRecord::Base
   def self.destroy_stale(before: 15.days.ago)
     where("created_at < ?", before).destroy_all
   end
+
+  # Reconstruct the model for this draft using the saved attributes. Returns the
+  # model with updated attributes.
+  def assign_attributes_to(model)
+    valid_attributes = model_attributes.dup.delete_if { |k, _| !model.respond_to?(:"#{k}=") }
+    model.assign_attributes(valid_attributes)
+
+    model
+  end
 end


### PR DESCRIPTION
In the case where a field is removed or a form is otherwise changed to have new parameters, restoring a previously saved draft should not cause an error.