### PR TITLE
Do a best effort on assigning attributes for drafts

### DIFF
--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -39,8 +39,15 @@ class Draft < ActiveRecord::Base
   # Reconstruct the model for this draft using the saved attributes. Returns the
   # model with updated attributes.
   def assign_attributes_to(model)
-    valid_attributes = model_attributes.dup.delete_if { |k, _| !model.respond_to?(:"#{k}=") }
-    model.assign_attributes(valid_attributes)
+    model_attributes.each_pair do |k, v|
+      model.public_send(:"#{k}=", v)
+    rescue NoMethodError
+      # This key is apparently invalid. We'll apply the other attributes and
+      # ignore this one.
+    rescue StandardError
+      # The value is apparently invalid. We'll apply the other attributes and
+      # ignore this one.
+    end
 
     model
   end

--- a/test/factories/benthic_covers.rb
+++ b/test/factories/benthic_covers.rb
@@ -9,5 +9,16 @@ FactoryBot.define do
     habitat_type
     meters_completed { 20 }
     sample_description { "Here is my sample" }
+    presence_belt
+  end
+
+  factory :presence_belt do
+    a_palmata { PresenceBelt::ENUM_VALUES.keys.sample }
+    a_cervicornis { PresenceBelt::ENUM_VALUES.keys.sample }
+    d_cylindrus { PresenceBelt::ENUM_VALUES.keys.sample }
+    m_ferox { PresenceBelt::ENUM_VALUES.keys.sample }
+    m_annularis { PresenceBelt::ENUM_VALUES.keys.sample }
+    m_franksi { PresenceBelt::ENUM_VALUES.keys.sample }
+    m_faveolata { PresenceBelt::ENUM_VALUES.keys.sample }
   end
 end


### PR DESCRIPTION
I found a couple more edge cases where prior versions of drafts could cause exceptions. This makes sure we're performing a best effort assignment. If something can't be applied properly, ignoring that single attribute is preferable to causing a full-blown error that will render the page as an HTTP 500 "Oops"