### PR TITLE
Improve dashboard query efficiency slightly

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -30,10 +30,10 @@ class DashboardController < ApplicationController
         }
       end
 
-      @data_by_divers[diver]["boat"] += boatlog_manager.boatlog_replicates_count_for_diver(diver)
-      @data_by_divers[diver]["sample"] += boatlog_manager.samples_count_for_diver(diver)
-      @data_by_divers[diver]["lpi"] += boatlog_manager.benthic_covers_count_for_diver(diver)
-      @data_by_divers[diver]["demo"] += boatlog_manager.coral_demographics_count_for_diver(diver)
+      @data_by_divers[diver]["boat"] += boatlog_manager.boatlog_replicates_for_diver(diver).count
+      @data_by_divers[diver]["sample"] += boatlog_manager.samples_for_diver(diver).count
+      @data_by_divers[diver]["lpi"] += boatlog_manager.benthic_covers_for_diver(diver).count
+      @data_by_divers[diver]["demo"] += boatlog_manager.coral_demographics_for_diver(diver).count
     end
   end
   @data_by_divers.sort_by { |diver, data| diver }

--- a/app/models/boat_log.rb
+++ b/app/models/boat_log.rb
@@ -13,8 +13,8 @@ class BoatLog < ActiveRecord::Base
 
   def boatlog_divers
     boatlog_divers_list = []
-    rep_logs.each do |rep|
-      boatlog_divers_list << [rep.station_log.boat_log.date, rep.field_id, rep.diver.diver_name]
+    rep_logs.includes([:diver]).each do |rep|
+      boatlog_divers_list << [date, rep.field_id, rep.diver.diver_name]
     end
     boatlog_divers_list.sort_by { |e| e[0] }
   end


### PR DESCRIPTION
This speeds up the dashboard a bit by adding `includes` and avoiding some N+1 queries.

There are some more nefarious N+1 queries (not picked up by bullet even) that need addressing, but they might require more time to unwind and I think they may change substantially if we add better side project management, so I decided to pause on doing anything more than this change for now.