### PR TITLE
Run yarn install as part of setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -16,6 +16,7 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
+  system("bin/yarn check") || system!("bin/yarn install")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")


### PR DESCRIPTION
This step was inadvertently removed as part of a recent upgrade. We do rely on JS dependencies so this needs to be here.