### PR TITLE
Standardize database configuration

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -21,6 +21,6 @@ test:
 production:
   <<: *common
   database: entryapplication_production
-  username: jeremiaheb
-  password: noaaRails
+  username: entryapplication_production
+  password: entryapplication_production
   pool: 5


### PR DESCRIPTION
We have transitioned to using service account users rather than humans.

This should work on both the old server and the new cloud instance.