### PR TITLE
Sort proofing report samples by date and also time (within the same date)

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -2,10 +2,6 @@ class SamplesController < ApplicationController
   before_action :authenticate_diver!
   load_and_authorize_resource
 
-  def current_ability
-    @current_ability ||= Ability.new(current_diver)
-  end
-
   # GET /samples
   # GET /samples.json
   def index

--- a/app/models/diver.rb
+++ b/app/models/diver.rb
@@ -21,15 +21,15 @@ class Diver < ActiveRecord::Base
   scope       :active_divers,      lambda { where(active: true) }
 
   def diver_proofing_samples
-    samples.order("sample_date")
+    samples.order(:sample_date, :sample_begin_time)
   end
 
   def diver_proofing_benthic_cover
-    benthic_covers.order("sample_date")
+    benthic_covers.order(:sample_date, :sample_begin_time)
   end
 
   def diver_proofing_coral_demo
-    coral_demographics.order("sample_date")
+    coral_demographics.order(:sample_date, :sample_begin_time)
   end
 
   def whole_name


### PR DESCRIPTION
Fixes #193 

The order of proofing reports within the same date was previously undefined. This adds a secondary sort column on `sample_begin_time` for each of the three types of proofing reports. If the sample date is the same, the records will be then sorted by time (ascending, earliest to latest) within that date.