### PR TITLE
Add ApplicationRecord

### DIFF
--- a/app/models/animal.rb
+++ b/app/models/animal.rb
@@ -1,4 +1,4 @@
-class Animal < ActiveRecord::Base
+class Animal < ApplicationRecord
   has_many :sample_animals, dependent: :restrict_with_error
   has_many :samples, through: :sample_animals
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  primary_abstract_class
+end

--- a/app/models/benthic_cover.rb
+++ b/app/models/benthic_cover.rb
@@ -1,4 +1,4 @@
-class BenthicCover < ActiveRecord::Base
+class BenthicCover < ApplicationRecord
   include CommonFields
 
   has_many :point_intercepts, dependent: :destroy

--- a/app/models/boat_log.rb
+++ b/app/models/boat_log.rb
@@ -1,4 +1,4 @@
-class BoatLog < ActiveRecord::Base
+class BoatLog < ApplicationRecord
   belongs_to :boatlog_manager
 
   has_many :station_logs, dependent: :destroy

--- a/app/models/boatlog_manager.rb
+++ b/app/models/boatlog_manager.rb
@@ -1,4 +1,4 @@
-class BoatlogManager < ActiveRecord::Base
+class BoatlogManager < ApplicationRecord
   has_many  :samples, dependent: :restrict_with_error
   has_one   :diver
   has_many  :benthic_covers, dependent: :restrict_with_error

--- a/app/models/coral.rb
+++ b/app/models/coral.rb
@@ -1,4 +1,4 @@
-class Coral < ActiveRecord::Base
+class Coral < ApplicationRecord
   has_many :demographic_corals, dependent: :restrict_with_error
   has_many :coral_demographics, through: :demographic_corals
 

--- a/app/models/coral_demographic.rb
+++ b/app/models/coral_demographic.rb
@@ -1,4 +1,4 @@
-class CoralDemographic < ActiveRecord::Base
+class CoralDemographic < ApplicationRecord
   include CommonFields
 
   has_many :demographic_corals, dependent: :destroy

--- a/app/models/cover_cat.rb
+++ b/app/models/cover_cat.rb
@@ -1,4 +1,4 @@
-class CoverCat < ActiveRecord::Base
+class CoverCat < ApplicationRecord
   has_many :point_intercepts, dependent: :restrict_with_error
   has_many :benthic_covers, through: :point_intercepts
 

--- a/app/models/demographic_coral.rb
+++ b/app/models/demographic_coral.rb
@@ -1,4 +1,4 @@
-class DemographicCoral < ActiveRecord::Base
+class DemographicCoral < ApplicationRecord
   belongs_to :coral_demographic
   belongs_to :coral
 

--- a/app/models/diver.rb
+++ b/app/models/diver.rb
@@ -1,4 +1,4 @@
-class Diver < ActiveRecord::Base
+class Diver < ApplicationRecord
   ADMIN   = "admin"
   MANAGER = "manager"
   DIVER   = "diver"

--- a/app/models/diver_sample.rb
+++ b/app/models/diver_sample.rb
@@ -1,4 +1,4 @@
-class DiverSample < ActiveRecord::Base
+class DiverSample < ApplicationRecord
   belongs_to :diver
   belongs_to :sample
 

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -1,4 +1,4 @@
-class Draft < ActiveRecord::Base
+class Draft < ApplicationRecord
   belongs_to :diver
   validates :diver_id, presence: true
 

--- a/app/models/habitat_type.rb
+++ b/app/models/habitat_type.rb
@@ -1,4 +1,4 @@
-class HabitatType < ActiveRecord::Base
+class HabitatType < ApplicationRecord
   VALID_REGIONS = [
     "Atlantic",
     "Caribbean",

--- a/app/models/invert_belt.rb
+++ b/app/models/invert_belt.rb
@@ -1,4 +1,4 @@
-class InvertBelt < ActiveRecord::Base
+class InvertBelt < ApplicationRecord
   belongs_to :benthic_cover
 
   validates :lobster_num,     presence: true

--- a/app/models/point_intercept.rb
+++ b/app/models/point_intercept.rb
@@ -1,4 +1,4 @@
-class PointIntercept < ActiveRecord::Base
+class PointIntercept < ApplicationRecord
   belongs_to  :benthic_cover
   belongs_to  :cover_cat
 

--- a/app/models/presence_belt.rb
+++ b/app/models/presence_belt.rb
@@ -1,4 +1,4 @@
-class PresenceBelt < ActiveRecord::Base
+class PresenceBelt < ApplicationRecord
   ENUM_VALUES = {
     "Absent"           => 0,
     "Present_Transect" => 1,

--- a/app/models/rep_log.rb
+++ b/app/models/rep_log.rb
@@ -1,4 +1,4 @@
-class RepLog < ActiveRecord::Base
+class RepLog < ApplicationRecord
   belongs_to  :station_log
   belongs_to  :diver
 

--- a/app/models/rugosity_measure.rb
+++ b/app/models/rugosity_measure.rb
@@ -1,4 +1,4 @@
-class RugosityMeasure < ActiveRecord::Base
+class RugosityMeasure < ApplicationRecord
   belongs_to :benthic_cover
 
   validates :min_depth,               presence: true

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -1,4 +1,4 @@
-class Sample < ActiveRecord::Base
+class Sample < ApplicationRecord
   include CommonFields
 
   belongs_to :diver

--- a/app/models/sample_animal.rb
+++ b/app/models/sample_animal.rb
@@ -1,4 +1,4 @@
-class SampleAnimal < ActiveRecord::Base
+class SampleAnimal < ApplicationRecord
   belongs_to :animal
   belongs_to :sample
 

--- a/app/models/sample_type.rb
+++ b/app/models/sample_type.rb
@@ -1,4 +1,4 @@
-class SampleType < ActiveRecord::Base
+class SampleType < ApplicationRecord
   has_many :samples, dependent: :restrict_with_error
 
   validates :sample_type_name, presence: true

--- a/app/models/station_log.rb
+++ b/app/models/station_log.rb
@@ -1,4 +1,4 @@
-class StationLog < ActiveRecord::Base
+class StationLog < ApplicationRecord
   belongs_to :boat_log
   has_many :rep_logs, dependent: :destroy
   accepts_nested_attributes_for :rep_logs, allow_destroy: true


### PR DESCRIPTION
Newer versions of Rails introduced an application-specific abstract class called `ApplicationRecord` that all models inherit from.

While we don't exactly need `ApplicationRecord` for anything at the moment, newer Rails generators (e.g., `bin/rails generate model`) assume it is there and therefore generate invalid code if it's not.

This PR introduces `ApplicationRecord` as it would be in a new Rails application, but it should not actually change any visible functionality.