### PR TITLE
Set default date client-side so it is based on the client's timezone

### DIFF
--- a/app/assets/javascripts/benthic_covers.js
+++ b/app/assets/javascripts/benthic_covers.js
@@ -9,11 +9,16 @@ $(function () {
     return;
   }
 
-  $("#benthic_cover_sample_date").datepicker({
+  const $benthicCoverSampleDate = $("#benthic_cover_sample_date");
+  $benthicCoverSampleDate.datepicker({
     format: "yyyy-mm-dd",
     orientation: "bottom",
     autoclose: true,
   });
+  if ($benthicCoverSampleDate.val() === "") {
+    // Default to today if not set
+    $benthicCoverSampleDate.datepicker("setDate", new Date());
+  }
 
   $("#benthic_cover_sample_begin_time").timepicker({
     timeFormat: "HH:mm",

--- a/app/assets/javascripts/boat_logs.js
+++ b/app/assets/javascripts/boat_logs.js
@@ -3,11 +3,16 @@ $(function () {
     return;
   }
 
-  $("#boat_log_date").datepicker({
+  const $boatLogDate = $("#boat_log_date");
+  $boatLogDate.datepicker({
     format: "yyyy-mm-dd",
     orientation: "bottom",
     autoclose: true,
   });
+  if ($boatLogDate.val() === "") {
+    // Default to today if not set
+    $boatLogDate.datepicker("setDate", new Date());
+  }
 
   $("#boat_log_station_logs_attributes_0_time").timepicker({
     timeFormat: "HH:mm",

--- a/app/assets/javascripts/coral_demographics.js
+++ b/app/assets/javascripts/coral_demographics.js
@@ -3,11 +3,16 @@ $(function () {
     return;
   }
 
-  $("#coral_demographic_sample_date").datepicker({
+  const $coralDemographicSampleDate = $("#coral_demographic_sample_date");
+  $coralDemographicSampleDate.datepicker({
     format: "yyyy-mm-dd",
     orientation: "bottom",
     autoclose: true,
   });
+  if ($coralDemographicSampleDate.val() === "") {
+    // Default to today if not set
+    $coralDemographicSampleDate.datepicker("setDate", new Date());
+  }
 
   $("#coral_demographic_sample_begin_time").timepicker({
     timeFormat: "HH:mm",

--- a/app/assets/javascripts/samples.js
+++ b/app/assets/javascripts/samples.js
@@ -482,11 +482,16 @@ $(function () {
     }
   });
 
-  $("#sample_sample_date").datepicker({
+  const $sampleSampleDate = $("#sample_sample_date");
+  $sampleSampleDate.datepicker({
     format: "yyyy-mm-dd",
     orientation: "bottom",
     autoclose: true,
   });
+  if ($sampleSampleDate.val() === "") {
+    // Default to today if not set
+    $sampleSampleDate.datepicker("setDate", new Date());
+  }
 
   $(
     "#sample_dive_begin_time, #sample_dive_end_time, #sample_sample_begin_time, #sample_sample_end_time",

--- a/app/controllers/benthic_covers_controller.rb
+++ b/app/controllers/benthic_covers_controller.rb
@@ -52,7 +52,6 @@ class BenthicCoversController < ApplicationController
       @benthic_cover = @draft.assign_attributes_to(BenthicCover.new)
     else
       @benthic_cover = BenthicCover.new.tap do |b|
-        b.sample_date ||= Date.current
         b.diver_id ||= current_diver.id
         b.build_invert_belt
         b.build_presence_belt

--- a/app/controllers/boat_logs_controller.rb
+++ b/app/controllers/boat_logs_controller.rb
@@ -40,7 +40,6 @@ class BoatLogsController < ApplicationController
       @boat_log = @draft.assign_attributes_to(BoatLog.new)
     else
       @boat_log = BoatLog.new.tap do |bl|
-        bl.date ||= Date.current
         station = bl.station_logs.build
         2.times { station.rep_logs.build }
       end

--- a/app/controllers/coral_demographics_controller.rb
+++ b/app/controllers/coral_demographics_controller.rb
@@ -52,7 +52,6 @@ class CoralDemographicsController < ApplicationController
       @coral_demographic = @draft.assign_attributes_to(CoralDemographic.new)
     else
       @coral_demographic = CoralDemographic.new.tap do |c|
-        c.sample_date ||= Date.current
         c.diver_id ||= current_diver.id
         c.demographic_corals.build
       end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -61,7 +61,6 @@ class SamplesController < ApplicationController
       @sample = @draft.assign_attributes_to(Sample.new)
     else
       @sample = Sample.new.tap do |s|
-        s.sample_date ||= Date.current
         s.sample_type ||= SampleType.default
         s.sample_animals.build
       end


### PR DESCRIPTION
This was a regression from a refactor I did earlier. `Date.current` will give the server's view of the current date, which may not (and likely _will_ not) be in the same timezone as the user. For UTC+0/GMT+0, typically the server will arrive at "tomorrow" ~4-5 hours earlier than someone on the east coast or USVI.

Long story short, the default date should go back to being set by JavaScript client-side.