### PR TITLE
Add default diver (current diver) for samples

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -61,6 +61,7 @@ class SamplesController < ApplicationController
       @sample = @draft.assign_attributes_to(Sample.new)
     else
       @sample = Sample.new.tap do |s|
+        s.diver_id ||= current_diver.id
         s.sample_type ||= SampleType.default
         s.sample_animals.build
       end


### PR DESCRIPTION
In https://github.com/jeremiaheb/EntryApplication/pull/181/files#diff-19056eb52b3cf883f6f055f839e1624f70c1e5f0f275de478e380bccd40a58f6L4 I inadvertently removed the code that selected the current diver as the default diver.

The controller now sets the default diver_id correctly. This line of code is already present for coral demographics and benthic covers, but it had regressed for fish samples.