### PR TITLE
Rename buddy to buddy_id and use a "real" belongs_to relationship

### DIFF
--- a/app/assets/javascripts/benthic_covers.js
+++ b/app/assets/javascripts/benthic_covers.js
@@ -184,7 +184,7 @@ $(function () {
       "benthic_cover[diver_id]": {
         required: true,
       },
-      "benthic_cover[buddy]": {
+      "benthic_cover[buddy_id]": {
         required: true,
       },
       "benthic_cover[field_id]": {

--- a/app/assets/javascripts/coral_demographics.js
+++ b/app/assets/javascripts/coral_demographics.js
@@ -107,7 +107,7 @@ $(function () {
       "coral_demographic[diver_id]": {
         required: true,
       },
-      "coral_demographic[buddy]": {
+      "coral_demographic[buddy_id]": {
         required: true,
       },
       "coral_demographic[field_id]": {

--- a/app/controllers/benthic_covers_controller.rb
+++ b/app/controllers/benthic_covers_controller.rb
@@ -150,7 +150,7 @@ class BenthicCoversController < ApplicationController
   private
 
   def benthic_cover_params
-    params.require(:benthic_cover).permit(:id, "_destroy", :boatlog_manager_id, :diver_id, :buddy, :field_id, :sample_date, :sample_begin_time, :habitat_type_id, :meters_completed, :sample_description,
+    params.require(:benthic_cover).permit(:id, "_destroy", :boatlog_manager_id, :diver_id, :buddy_id, :field_id, :sample_date, :sample_begin_time, :habitat_type_id, :meters_completed, :sample_description,
                                          point_intercepts_attributes: [:id, "_destroy", :cover_cat_id, :hardbottom_num, :softbottom_num, :rubble_num],
                                          rugosity_measure_attributes: [:id, "_destroy", :min_depth, :max_depth, :rug_meters_completed, :meter_mark_1,
                                                                       :meter_mark_2, :meter_mark_3, :meter_mark_4, :meter_mark_5, :meter_mark_6,

--- a/app/models/benthic_cover.rb
+++ b/app/models/benthic_cover.rb
@@ -6,6 +6,7 @@ class BenthicCover < ApplicationRecord
   accepts_nested_attributes_for :point_intercepts, allow_destroy: true
 
   belongs_to :diver
+  belongs_to :buddy, class_name: "Diver"
   belongs_to :habitat_type
   belongs_to :boatlog_manager
 
@@ -19,7 +20,7 @@ class BenthicCover < ApplicationRecord
 
   validates :boatlog_manager_id,    presence: true
   validates :diver_id,              presence: true
-  validates :buddy,                 presence: true
+  validates :buddy_id,              presence: true
   validates :sample_date,           presence: true
   validates :sample_begin_time,     presence: true
   validates :field_id,              presence: true, length: { minimun: 6, maximum: 6 }

--- a/app/models/coral_demographic.rb
+++ b/app/models/coral_demographic.rb
@@ -7,13 +7,14 @@ class CoralDemographic < ApplicationRecord
   validates_presence_of :demographic_corals, message: "you must have at leat one coral record (can be NO CORAL)"
 
   belongs_to :diver
+  belongs_to :buddy, class_name: "Diver"
   belongs_to :habitat_type
   belongs_to :boatlog_manager
 
 
   validates :boatlog_manager_id,    presence: true
   validates :diver_id,              presence: true
-  validates :buddy,                 presence: true
+  validates :buddy_id,              presence: true
   validates :sample_date,           presence: true
   validates :sample_begin_time,     presence: true
   validates :field_id,              presence: true, length: { minimun: 6, maximum: 6 }

--- a/app/pdfs/benthic_cover_pdf.rb
+++ b/app/pdfs/benthic_cover_pdf.rb
@@ -26,7 +26,7 @@ class BenthicCoverPdf < Prawn::Document
 
   def sample_head
     data =  [["Diver", "#{@benthic_cover.diver.diver_name}", "Boatlog/Manger:", "#{@benthic_cover.boatlog_manager.agency_name}"],
-              ["Buddy", "#{Diver.find(@benthic_cover.buddy).diver_name}", "Field ID", "#{@benthic_cover.field_id}", "Date", "#{@benthic_cover.sample_date}", "Sample Time", "#{@benthic_cover.sample_begin_time.strftime("%H:%M")}"],
+              ["Buddy", "#{@benthic_cover.buddy.diver_name}", "Field ID", "#{@benthic_cover.field_id}", "Date", "#{@benthic_cover.sample_date}", "Sample Time", "#{@benthic_cover.sample_begin_time.strftime("%H:%M")}"],
               ["Habitat", "#{@benthic_cover.habitat_type.habitat_name}", "Meters Completed", "#{@benthic_cover.meters_completed}"],
 ]
     table data, cell_style: { size: 8, border_width: 0, height: 17, padding: 5 }

--- a/app/pdfs/coral_demographic_pdf.rb
+++ b/app/pdfs/coral_demographic_pdf.rb
@@ -23,7 +23,7 @@ class CoralDemographicPdf < Prawn::Document
 
   def sample_head
     data =  [["Diver", "#{@coral_demographic.diver.diver_name}", "Boatlog/Manger:", "#{@coral_demographic.boatlog_manager.agency_name}"],
-              ["Buddy", "#{Diver.find(@coral_demographic.buddy).diver_name}", "Field ID", "#{@coral_demographic.field_id}", "Date", "#{@coral_demographic.sample_date}", "Sample Time", "#{@coral_demographic.sample_begin_time.strftime("%H:%M")}"],
+              ["Buddy", "#{@coral_demographic.buddy.diver_name}", "Field ID", "#{@coral_demographic.field_id}", "Date", "#{@coral_demographic.sample_date}", "Sample Time", "#{@coral_demographic.sample_begin_time.strftime("%H:%M")}"],
               ["Habitat", "#{@coral_demographic.habitat_type.habitat_name}", "Meters Completed", "#{@coral_demographic.meters_completed}", "Percent Hardbottom", "#{@coral_demographic.percent_hardbottom}"],
 ]
     table data, cell_style: { size: 8, border_width: 0, height: 17, padding: 5 }

--- a/app/views/benthic_covers/_form.html.erb
+++ b/app/views/benthic_covers/_form.html.erb
@@ -32,7 +32,7 @@
         <div class="control-group">
           <label class="control-label">Buddy</label>
           <div class="controls">
-            <%= f.collection_select :buddy, Diver.active_divers.order(:diver_name), :id, :diver_name, :include_blank => true %><br />
+            <%= f.collection_select :buddy_id, Diver.active_divers.order(:diver_name), :id, :diver_name, :include_blank => true %><br />
           </div>
         </div>
 

--- a/app/views/benthic_covers/show.html.erb
+++ b/app/views/benthic_covers/show.html.erb
@@ -11,7 +11,7 @@
         <dt>Diver</dt><dd><%= @benthic_cover.diver.diver_name %></dd>
       </dl>
       <dl class="dl-horizontal">
-        <dt>Buddy</dt><dd><%= Diver.find(@benthic_cover.buddy).diver_name %></dd>
+        <dt>Buddy</dt><dd><%= @benthic_cover.buddy.diver_name %></dd>
       </dl>
       <dl class="dl-horizontal">
         <dt>Field ID</dt><dd><%= @benthic_cover.field_id %></dd>

--- a/app/views/coral_demographics/_form.html.erb
+++ b/app/views/coral_demographics/_form.html.erb
@@ -31,7 +31,7 @@
         <div class="control-group">
           <label class="control-label">Buddy</label>
           <div class="controls">
-            <%= f.collection_select :buddy, Diver.active_divers.order(:diver_name), :id, :diver_name, :include_blank => true %><br />
+            <%= f.collection_select :buddy_id, Diver.active_divers.order(:diver_name), :id, :diver_name, :include_blank => true %><br />
           </div>
         </div>
 

--- a/app/views/coral_demographics/index.xlsx.axlsx
+++ b/app/views/coral_demographics/index.xlsx.axlsx
@@ -18,7 +18,7 @@ wb.add_worksheet(name: "CoralDemoSample") do |sampSheet|
   @coral_demographics.each do |c_demo|
     sampSheet.add_row [c_demo.msn,
                         c_demo.diver.diver_number,
-                        Diver.find(c_demo.buddy).diver_number,
+                        c_demo.buddy.diver_number,
                         c_demo.habitat_type.id,
                         c_demo.habitat_type.habitat_name,
                         c_demo.sample_date.strftime("%Y"),

--- a/app/views/coral_demographics/show.html.erb
+++ b/app/views/coral_demographics/show.html.erb
@@ -11,7 +11,7 @@
         <dt>Diver</dt><dd><%= @coral_demographic.diver.diver_name %></dd>
       </dl>
       <dl class="dl-horizontal">
-        <dt>Buddy</dt><dd><%= Diver.find(@coral_demographic.buddy).diver_name %></dd>
+        <dt>Buddy</dt><dd><%= @coral_demographic.buddy.diver_name %></dd>
       </dl>
       <dl class="dl-horizontal">
         <dt>Field ID</dt><dd><%= @coral_demographic.field_id %></dd>

--- a/db/migrate/20250814192342_rename_buddy_to_buddy_id.rb
+++ b/db/migrate/20250814192342_rename_buddy_to_buddy_id.rb
@@ -1,0 +1,6 @@
+class RenameBuddyToBuddyId < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :benthic_covers, :buddy, :buddy_id
+    rename_column :coral_demographics, :buddy, :buddy_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_06_161152) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_14_192342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_06_161152) do
   create_table "benthic_covers", force: :cascade do |t|
     t.integer "diver_id"
     t.integer "habitat_type_id"
-    t.integer "buddy"
+    t.integer "buddy_id"
     t.string "field_id"
     t.date "sample_date"
     t.time "sample_begin_time"
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_06_161152) do
   create_table "coral_demographics", force: :cascade do |t|
     t.integer "diver_id"
     t.integer "habitat_type_id"
-    t.integer "buddy"
+    t.integer "buddy_id"
     t.string "field_id"
     t.date "sample_date"
     t.time "sample_begin_time"

--- a/test/factories/benthic_covers.rb
+++ b/test/factories/benthic_covers.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :benthic_cover do
     boatlog_manager
     diver
-    sequence(:buddy)
+    buddy factory: :diver
     sample_date { Date.parse("2013-09-15") }
     sample_begin_time { Time.parse("2013-09-15T15:00:00Z") }
     field_id { "10011a" }

--- a/test/factories/coral_demographics.rb
+++ b/test/factories/coral_demographics.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :coral_demographic do
     boatlog_manager
     diver
-    sequence(:buddy)              { |n| "buddy#{n}" }
+    buddy factory: :diver
     field_id { "10011A" }
     sequence(:meters_completed)
     sequence(:sample_begin_time)  { |n| Time.current }

--- a/test/system/benthic_covers_test.rb
+++ b/test/system/benthic_covers_test.rb
@@ -21,7 +21,7 @@ class BenthicCoversTest < ApplicationSystemTestCase
     # TODO: If reuse is desired, extract this complex input to a function
     find("select#benthic_cover_boatlog_manager_id").select(boatlog_manager.agency_name)
     find("select#benthic_cover_diver_id").select(diver.diver_name)
-    find("select#benthic_cover_buddy").select(buddy.diver_name)
+    find("select#benthic_cover_buddy_id").select(buddy.diver_name)
     find("input#benthic_cover_field_id").fill_in(with: "30591A")
     find("input#benthic_cover_sample_date").fill_in(with: "2025-01-17")
     find("body").click # blur for calendar popup

--- a/test/system/coral_demographics_test.rb
+++ b/test/system/coral_demographics_test.rb
@@ -21,7 +21,7 @@ class CoralDemographicsTest < ApplicationSystemTestCase
     # TODO: If reuse is desired, extract this complex input to a function
     find("select#coral_demographic_boatlog_manager_id").select(boatlog_manager.agency_name)
     find("select#coral_demographic_diver_id").select(diver.diver_name)
-    find("select#coral_demographic_buddy").select(buddy.diver_name)
+    find("select#coral_demographic_buddy_id").select(buddy.diver_name)
     find("input#coral_demographic_field_id").fill_in(with: "30591A")
     find("input#coral_demographic_sample_date").fill_in(with: "2025-01-17")
     find("body").click # blur for calendar popup


### PR DESCRIPTION
I had already changed this for `Sample`, but it needed to be done for the other two sample types.

It is better to let Rails manage this relationship than doing it manually via `Diver.find(id)`. And it should make it easier to eager load this association when optimizing queries via `includes`.
