### PR TITLE
[Work in progress] Add background color to bleaching/disease proofing report cells

### DIFF
--- a/app/pdfs/coral_demographic_pdf.rb
+++ b/app/pdfs/coral_demographic_pdf.rb
@@ -42,7 +42,14 @@ class CoralDemographicPdf < Prawn::Document
  def species_data_30
    table spp_1_30,
     cell_style: { size: 8, height: 17, align: :center, padding: 2 },
-    column_widths: { 0 => 10, 1 => 60, 2 => 100, 3 => 30, 4 => 30, 5 => 30, 6 => 30 }
+    column_widths: { 0 => 10, 1 => 60, 2 => 100, 3 => 30, 4 => 30, 5 => 30, 6 => 30 } do
+      cells.style do |cell|
+        # Highlight bleaching other than "none"
+        cell.background_color = "f2938c" if cell.row > 0 && cell.column == 5 && cell.content.downcase != "n"
+        # Highlight disease other than "absent"
+        cell.background_color = "f2938c" if cell.row > 0 && cell.column == 6 && cell.content.downcase != "absent"
+      end
+    end
  end
 
  def spp_1_30


### PR DESCRIPTION
Add background color to some of the fields in the CoralDemographic report to get feedback on the approach.

This is incomplete because it is only applied to the first 30 species data. If we like the approach, it will need to get added to the other columns' code too.