### PR TITLE
Support server config and code deployment on cloud instances

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,6 +43,9 @@ set :ssh_options, forward_agent: true
 # rbenv settings
 set :rbenv_type, :user
 
+# Public assets must be readable by Apache
+SSHKit.config.umask = "0002"
+
 namespace :deploy do
   namespace :check do
     before :linked_files, :upload_encryption_keys do

--- a/config/deploy/production_cloud.rb
+++ b/config/deploy/production_cloud.rb
@@ -1,0 +1,10 @@
+set :stage, :production_cloud
+set :rails_env, "production"
+
+# Proxy through Google Cloud IAP
+# https://cloud.google.com/iap/docs/using-tcp-forwarding
+set :ssh_options, {
+  proxy: Net::SSH::Proxy::Command.new(File.join(__dir__, "..", "..", "server", "gcloud-iap-tunnel") + " %h %p"),
+}
+
+server "sefsc-ncrmp-web-prod.us-east4-a.ggn-nmfs-sencrmp-prod-1", user: "entryapplication", roles: %w[app db web]

--- a/server/gcloud-ansible-ssh
+++ b/server/gcloud-ansible-ssh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#/ Set as the ansible_ssh_executable to allow Ansible to connect a Google Cloud
+#/ virtual machine via https://cloud.google.com/compute/docs/oslogin/set-up-oslogin
+#/
+#/ Requires 'gcloud auth login' to have been previously run
+set -euo pipefail
+[ -n "${DEBUG-}" ] && set -x
+
+# Fullhost is the second to last argument, in the form NAME.ZONE.PROJECT
+# See https://cloud.google.com/sdk/gcloud/reference/compute/config-ssh
+fullhost="${*:$#-1:1}"
+
+# Split fullhost into its component parts
+IFS="." read -r host zone project <<<"$fullhost"
+
+# The command is the last argument
+command="${*:$#:1}"
+
+exec gcloud --project="$project" compute ssh "$host" --zone="$zone" --command="$command" -- "${@:1:$#-2}"

--- a/server/gcloud-iap-tunnel
+++ b/server/gcloud-iap-tunnel
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#/ Creates a tunnel to a Google Cloud virtual machine via https://cloud.google.com/security/products/iap
+#/ Necessary for cloud virtual machines that do not have a public IP address
+#/ 
+#/ Exmaple usage via ssh ProxyCommand (see `man ssh_config`):
+#/ ssh -o 'ProxyCommand=/path/to/gcloud-iap-tunnel %h %p' USER@NAME.ZONE.PROJECT
+#/
+#/ Requires 'gcloud auth login' to have been previously run
+set -euo pipefail
+[ -n "${DEBUG-}" ] && set -x
+
+if [ "$#" != 2 ]; then
+  echo "Usage: $0 NAME.ZONE.PROJECT PORT" >&2
+  exit 1
+fi
+
+# fullhost is in the form NAME.ZONE.PROJECT
+# See https://cloud.google.com/sdk/gcloud/reference/compute/config-ssh
+fullhost="$1"
+
+# Split fullhost into its component parts
+IFS="." read -r host zone project <<<"$fullhost"
+
+# port is generally "22" for SSH
+port="$2"
+
+exec gcloud --project="$project" compute start-iap-tunnel --zone="$zone" --listen-on-stdin "$host" "$port"

--- a/server/production.yml
+++ b/server/production.yml
@@ -1,0 +1,4 @@
+web:
+  hosts:
+    "sefsc-ncrmp-web-prod.us-east4-a.ggn-nmfs-sencrmp-prod-1":
+      ansible_ssh_executable: "{{ inventory_dir }}/gcloud-ansible-ssh"


### PR DESCRIPTION
Google Cloud has some unique networking and authentication mechanisms. This PR adds some wrapper scripts (usable with `ProxyCommand` or as the SSH executable that Ansible uses) to facilitate these.

Once we are sure about the direction, I will document things a bit better. The most notable change is the need to run `gcloud auth login` within the Vagrant VM before running Ansible or Capistrano.