### PR TITLE
Allow bg classes to override table strips

### DIFF
--- a/app/assets/stylesheets/_uswds-theme-custom-styles.scss
+++ b/app/assets/stylesheets/_uswds-theme-custom-styles.scss
@@ -50,10 +50,14 @@ span.error {
 }
 
 .usa-table {
-  .bg-secondary-lighter {
-    @include u-bg("secondary-lighter");
-  }
-  .bg-secondary-light {
-    @include u-bg("secondary-light");
+  tr,
+  td,
+  th {
+    &.bg-secondary-lighter {
+      @include u-bg("secondary-lighter", "!important");
+    }
+    &.bg-secondary-light {
+      @include u-bg("secondary-light", "!important");
+    }
   }
 }


### PR DESCRIPTION
Not the most elegant, but I think it's contained enough. The USWDS selector for a striped row is coming through as more specific than `bg-secondary-lighter`. Add `!important` to make it clear we want this to override.