### PR TITLE
Add capybara-lockstep to workaround system test flakiness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,5 +66,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  # Workaround for https://github.com/teamcapybara/capybara/issues/2800
+  gem "capybara-lockstep"
   gem "selenium-webdriver"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-lockstep (2.3.0)
+      activesupport (>= 4.2)
+      capybara (>= 3.0)
+      ruby2_keywords
     caxlsx (4.4.0)
       htmlentities (~> 4.3, >= 4.3.4)
       marcel (~> 1.0)
@@ -371,6 +375,7 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (3.1.1)
     sass-embedded (1.89.2-x64-mingw-ucrt)
       google-protobuf (~> 4.31)
@@ -464,6 +469,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rbenv
   capybara
+  capybara-lockstep
   caxlsx_rails (~> 0.6.4)
   csv (~> 3.3, >= 3.3.5)
   dartsass-sprockets (~> 3.2, >= 3.2.1)

--- a/app/views/layouts/application-uswds.html.erb
+++ b/app/views/layouts/application-uswds.html.erb
@@ -11,6 +11,7 @@
     <%= stylesheet_link_tag "uswds-styles", "application-uswds", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <%= javascript_include_tag "@uswds/uswds/dist/js/uswds-init" %>
+    <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
   </head>
 
   <body class="<%= controller_name %> <%= action_name %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "RVC Data Entry System" %>">
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
+    <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= yield(:head) %>


### PR DESCRIPTION
There appears to be a known issue with Chrome >= 135 and system tests being flaky. The `capybara-lockstep` gem may help by avoiding the race conditions that seem to trigger the bad behavior.