### PR TITLE
Pin Python to 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3"
+          python-version: "3.13"
 
       - name: Install Python dependencies
         run: pip install --requirement requirements.txt


### PR DESCRIPTION
> RuntimeError: Python 3.14 requires ansible-core version >= 2.20.0, and we found 2.17.14.

ansible-core is pinned to the version that is installed in Ubuntu by default. Until that is upgraded, pin Python to a supported version.