### PR TITLE
Remove ensure latest flag

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
-
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
We should upgrade brakeman when we can, but having it outright fail in the meantime is a bit much.