### PR TITLE
Remove pip from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
We are matching ansible and ansible-lint to what is installable in Ubuntu 22.04. Dependabot keeps trying to upgrade it beyond what can be installed.