### PR TITLE
Increase ansible_become_timeout for cloud instances

### DIFF
--- a/server/production_cloud.yml
+++ b/server/production_cloud.yml
@@ -2,3 +2,4 @@ web:
   hosts:
     "sefsc-ncrmp-web-prod.us-east4-a.ggn-nmfs-sencrmp-prod-1":
       ansible_ssh_executable: "{{ inventory_dir }}/gcloud-ansible-ssh"
+      ansible_become_timeout: 60


### PR DESCRIPTION
It seems like cloud instances need a bit more time for the privilege escalation prompt in some cases.