### PR TITLE
Remove format hidden field tag

### DIFF
--- a/app/views/benthic_covers/index.html.erb
+++ b/app/views/benthic_covers/index.html.erb
@@ -70,8 +70,7 @@
                   Diver Proofing Reports
                 </h2>
                 <div id="diver-proofing-report-modal-description">
-                  <%= form_tag benthic_covers_path, class: "usa-form", method: "get" do %>
-                    <%= hidden_field_tag :format, "pdf" %>
+                  <%= form_tag benthic_covers_path(format: "pdf"), class: "usa-form", method: "get" do %>
                     <%- Array(params[:region_ids]).each do |region_id| %>
                       <%= hidden_field_tag :"region_ids[]", region_id %>
                     <%- end %>

--- a/app/views/coral_demographics/index.html.erb
+++ b/app/views/coral_demographics/index.html.erb
@@ -70,8 +70,7 @@
                   Diver Proofing Reports
                 </h2>
                 <div id="diver-proofing-report-modal-description">
-                  <%= form_tag coral_demographics_path, class: "usa-form", method: "get" do %>
-                    <%= hidden_field_tag :format, "pdf" %>
+                  <%= form_tag coral_demographics_path(format: "pdf"), class: "usa-form", method: "get" do %>
                     <%- Array(params[:region_ids]).each do |region_id| %>
                       <%= hidden_field_tag :"region_ids[]", region_id %>
                     <%- end %>

--- a/app/views/samples/index.html.erb
+++ b/app/views/samples/index.html.erb
@@ -80,8 +80,7 @@
                   Diver Proofing Reports
                 </h2>
                 <div id="diver-proofing-report-modal-description">
-                  <%= form_tag samples_path, class: "usa-form", method: "get" do %>
-                    <%= hidden_field_tag :format, "pdf" %>
+                  <%= form_tag samples_path(format: "pdf"), class: "usa-form", method: "get" do %>
                     <%- Array(params[:region_ids]).each do |region_id| %>
                       <%= hidden_field_tag :"region_ids[]", region_id %>
                     <%- end %>


### PR DESCRIPTION
For some reason, we are getting a 403 Forbidden error when the URL contains a format=pdf parameter.

This will generate a URL that embeds the format in a different way that does not trigger the error.