### PR TITLE
Show a banner when a draft is pending

### DIFF
--- a/app/assets/javascripts/drafts.js
+++ b/app/assets/javascripts/drafts.js
@@ -115,6 +115,8 @@ $(function () {
     $form.on(
       "draft:pending",
       _.once(function (e) {
+        $(".draft-saved-alert").show();
+
         window.addEventListener("beforeunload", warnBeforeUnload);
         saveDraftInterval = setInterval(function () {
           saveDraftThrottled(e);

--- a/app/views/application/_draft_present_alert.html.erb
+++ b/app/views/application/_draft_present_alert.html.erb
@@ -13,3 +13,11 @@
     </div>
   </div>
 <%- end %>
+
+<%= tag.div class: "usa-alert usa-alert--error usa-alert--slim margin-y-1 alert draft-saved-alert", style: (@draft.present? ? "" : "display: none") do %>
+  <div class="usa-alert__body">
+    <p class="usa-alert__text">
+      Please fully save the record when you are finished. A draft is only temporary.
+    </p>
+  </div>
+<%- end %>


### PR DESCRIPTION
When a draft is pending, we want it to be more visually apparent that a diver needs to fully save the record for it to be fully persisted.

Supersedes #342 