### PR TITLE
Cron task to delete drafts older than 30 days

### DIFF
--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -32,7 +32,7 @@ class Draft < ApplicationRecord
 
   # Destroy all drafts created before a certain time, which by now are no longer
   # useful and just clogging up the database.
-  def self.destroy_stale(before: 15.days.ago)
+  def self.destroy_stale(before: 30.days.ago)
     where("created_at < ?", before).destroy_all
   end
 

--- a/server/playbook.yml
+++ b/server/playbook.yml
@@ -564,6 +564,16 @@
         mode: "0440"
       become: true
 
+    - name: Cleanup stale drafts on a schedule
+      ansible.builtin.cron:
+        name: "Delete stale drafts older than 30 days"
+        minute: "30"
+        hour: "23"
+        user: "entryapplication"
+        job: >
+          cd /var/www/apps/EntryApplication/current && $HOME/.rbenv/bin/rbenv exec bundle exec rake drafts:destroy_stale RAILS_ENV=production
+      become: true
+
     - name: Backup the database on a schedule
       ansible.builtin.cron:
         name: "Backup database"


### PR DESCRIPTION
This task has existed for a little while, but has never been enabled.

Need to discuss with Jeremiah: Do we want to delete drafts that seem stale? Or is there value in keeping them so divers can be pinged to make sure they didn't leave something hanging?