### PR TITLE
Fix deprecation warning for unused scope methods

### DIFF
--- a/app/models/demographic_coral.rb
+++ b/app/models/demographic_coral.rb
@@ -4,7 +4,7 @@ class DemographicCoral < ApplicationRecord
 
   default_scope -> { order("id ASC") }
 
-  enum :restored, [:not_restored, :restored, :unknown]
+  enum :restored, [:not_restored, :restored, :unknown], scopes: false, instance_methods: false
 
   validates   :meter_mark, :max_diameter, :perpendicular_diameter, :height, :old_mortality, :recent_mortality, :bleach_condition, :disease, presence: true, if: -> { coral_id != 1 }
   validates   :max_diameter, :perpendicular_diameter, :height, numericality: { greater_than: 0 }

--- a/app/models/presence_belt.rb
+++ b/app/models/presence_belt.rb
@@ -16,11 +16,11 @@ class PresenceBelt < ApplicationRecord
   validates :m_franksi,         presence: true
   validates :m_faveolata,       presence: true
 
-  enum :a_palmata,     ENUM_VALUES, instance_methods: false
-  enum :a_cervicornis, ENUM_VALUES, instance_methods: false
-  enum :d_cylindrus,   ENUM_VALUES, instance_methods: false
-  enum :m_ferox,       ENUM_VALUES, instance_methods: false
-  enum :m_annularis,   ENUM_VALUES, instance_methods: false
-  enum :m_franksi,     ENUM_VALUES, instance_methods: false
-  enum :m_faveolata,   ENUM_VALUES, instance_methods: false
+  enum :a_palmata,     ENUM_VALUES, scopes: false, instance_methods: false
+  enum :a_cervicornis, ENUM_VALUES, scopes: false, instance_methods: false
+  enum :d_cylindrus,   ENUM_VALUES, scopes: false, instance_methods: false
+  enum :m_ferox,       ENUM_VALUES, scopes: false, instance_methods: false
+  enum :m_annularis,   ENUM_VALUES, scopes: false, instance_methods: false
+  enum :m_franksi,     ENUM_VALUES, scopes: false, instance_methods: false
+  enum :m_faveolata,   ENUM_VALUES, scopes: false, instance_methods: false
 end


### PR DESCRIPTION
We do not actually use these scopes or instance methods