### PR TITLE
Do not manage human passwords

### DIFF
--- a/server/playbook.yml
+++ b/server/playbook.yml
@@ -163,7 +163,6 @@
       ansible.builtin.user:
         name: "alindeman"
         create_home: true
-        password: "!" # disable password
         shell: /bin/bash
         groups:
           - users
@@ -184,7 +183,6 @@
       ansible.builtin.user:
         name: "jeremiaheb"
         create_home: true
-        password: "!" # disable password
         shell: /bin/bash
         groups:
           - users


### PR DESCRIPTION
The default will be `!` but if a sysadmin wants to change them, we should let them.